### PR TITLE
Fix spring-webmvc version mismatch between gravitee (spring 4.2.6) and spring-security-oauth2 (4.0.9)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,11 @@
                 <artifactId>spring-web</artifactId>
                 <version>${spring.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This closes gravitee-io/issues#116