### PR TITLE
fix(oauth2): Use the value of picture property instead of the key itself

### DIFF
--- a/gravitee-management-api-rest/src/main/java/io/gravitee/management/rest/resource/auth/OAuth2AuthenticationResource.java
+++ b/gravitee-management-api-rest/src/main/java/io/gravitee/management/rest/resource/auth/OAuth2AuthenticationResource.java
@@ -118,7 +118,7 @@ public class OAuth2AuthenticationResource extends AbstractAuthenticationResource
         // User refresh
         UpdateUserEntity user = new UpdateUserEntity();
         user.setUsername(username);
-        user.setPicture((String) authenticationProvider.configuration().get("mapping.picture"));
+        user.setPicture((String) userInfo.get(authenticationProvider.configuration().get("mapping.picture")));
 
         userService.update(user);
 


### PR DESCRIPTION
Closes gravitee-io/issues#675