### PR TITLE
feat(healthcheck): Update default HTTP port from 8093 to 18083

### DIFF
--- a/gravitee-management-api-standalone/gravitee-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-management-api-standalone/gravitee-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -94,7 +94,7 @@ services:
   core:
     http:
       enabled: true
-      port: 8093
+      port: 18083
       host: localhost
       authentication:
         type: basic


### PR DESCRIPTION
Closes gravitee-io/issues#712