### PR TITLE
fix(management-api): Allow for customization of password encoding/hashing algorithm for the InMemory IDP

### DIFF
--- a/gravitee-management-api-standalone/gravitee-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-management-api-standalone/gravitee-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -120,6 +120,11 @@ analytics:
 security:
   providers:  # authentication providers
     - type: memory
+      # password encoding/hashing algorithm. One of:
+      # - bcrypt : passwords are hashed with bcrypt
+      # - none : passwords are not hashed/encrypted
+      # default value is bcrypt
+      password-encoding-algo: bcrypt
       users:
         - user:
           username: user


### PR DESCRIPTION
fix(management-api): Allow for customization of password encoding/hashing algorithm for the InMemory IDP

Closes gravitee-io/issues#804