### PR TITLE
fix: API logos are not displayed correctly over HTTPS on apis list

### DIFF
--- a/gravitee-management-api-rest/src/main/java/io/gravitee/management/rest/resource/ApisResource.java
+++ b/gravitee-management-api-rest/src/main/java/io/gravitee/management/rest/resource/ApisResource.java
@@ -212,8 +212,8 @@ public class ApisResource extends AbstractResource {
         apiItem.setVersion(api.getVersion());
         apiItem.setDescription(api.getDescription());
 
-        final UriBuilder ub = uriInfo.getBaseUriBuilder();
-        final UriBuilder uriBuilder = ub.path("apis").path(api.getId()).path("picture");
+        final UriBuilder ub = uriInfo.getAbsolutePathBuilder();
+        final UriBuilder uriBuilder = ub.path(api.getId()).path("picture");
         if (api.getPicture() != null) {
             // force browser to get if updated
             uriBuilder.queryParam("hash", api.getPicture().hashCode());


### PR DESCRIPTION
This closes gravitee-io/issues#1142