### PR TITLE
feat(config): Add support for X-Forwarded headers

### DIFF
--- a/gravitee-management-api-standalone/gravitee-management-api-standalone-container/src/main/java/io/gravitee/management/standalone/jetty/JettyConfiguration.java
+++ b/gravitee-management-api-standalone/gravitee-management-api-standalone-container/src/main/java/io/gravitee/management/standalone/jetty/JettyConfiguration.java
@@ -62,6 +62,9 @@ public class JettyConfiguration {
     @Value("${jetty.accesslog.path:${gravitee.home}/logs/gravitee_accesslog_yyyy_mm_dd.log}")
     private String accessLogPath;
 
+    @Value("${jetty.forwardedRequests:false}")
+    private boolean forwardedRequests;
+
     public String getHttpHost() {
       return httpHost;
     }
@@ -164,5 +167,13 @@ public class JettyConfiguration {
 
     public void setAccessLogPath(String accessLogPath) {
         this.accessLogPath = accessLogPath;
+    }
+
+    public boolean isForwardedRequests() {
+        return forwardedRequests;
+    }
+
+    public void setForwardedRequests(boolean forwardedRequests) {
+        this.forwardedRequests = forwardedRequests;
     }
 }

--- a/gravitee-management-api-standalone/gravitee-management-api-standalone-container/src/main/java/io/gravitee/management/standalone/jetty/JettyServerFactory.java
+++ b/gravitee-management-api-standalone/gravitee-management-api-standalone-container/src/main/java/io/gravitee/management/standalone/jetty/JettyServerFactory.java
@@ -70,6 +70,11 @@ public class JettyServerFactory implements FactoryBean<Server> {
         httpConfig.setSendServerVersion(false);
         httpConfig.setSendDateHeader(false);
 
+        // support x-forwarded Headers
+        if (jettyConfiguration.isForwardedRequests()) {
+            httpConfig.addCustomizer(new ForwardedRequestCustomizer());
+        }
+
         // Setup Jetty HTTP Connector
         ServerConnector http = new ServerConnector(server,
                 jettyConfiguration.getAcceptors(),

--- a/gravitee-management-api-standalone/gravitee-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-management-api-standalone/gravitee-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -29,6 +29,7 @@
 #  accesslog:
 #    enabled: true
 #    path: ${gravitee.home}/logs/gravitee_accesslog_yyyy_mm_dd.log
+#  forwardedRequests: false
 
 http:
   cors:


### PR DESCRIPTION
By default the Jetty Server ignores X-Forwarded headers and the Gravitee Management API doesn't support HTTPS.
Some Endpoints in Gravitee Management API return objects with Urls in it: e.g./management/apis/?view=all the picture_url parameter
This urls are build with UriInfo context based. The UriInfo Class also respects X-Forwarded-Proto header.
The ForwardedRequestCustomizer as it says respects the X-Forwarded headers