### PR TITLE
fix(api, app): keep old permissions when switch to a new app/api

### DIFF
--- a/gravitee-management-api-rest/src/main/java/io/gravitee/management/rest/resource/ApplicationMembersResource.java
+++ b/gravitee-management-api-rest/src/main/java/io/gravitee/management/rest/resource/ApplicationMembersResource.java
@@ -76,9 +76,6 @@ public class ApplicationMembersResource  extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "Application member's permissions", response = MemberEntity.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    @Permissions({
-            @Permission(value = RolePermission.APPLICATION_MEMBER, acls = RolePermissionAction.READ)
-    })
     public Response getPermissions(@PathParam("application") String application) {
         Map<String, char[]> permissions = new HashMap<>();
         if (isAuthenticated()) {


### PR DESCRIPTION
fix gravitee-io/issues#1535