### PR TITLE
fix(ldap): unable to map roles based on ldap group

### DIFF
--- a/gravitee-management-api-idp/gravitee-management-api-idp-ldap/src/main/java/io/gravitee/management/idp/ldap/authentication/LdapAuthenticationProvider.java
+++ b/gravitee-management-api-idp/gravitee-management-api-idp-ldap/src/main/java/io/gravitee/management/idp/ldap/authentication/LdapAuthenticationProvider.java
@@ -69,6 +69,8 @@ public class LdapAuthenticationProvider implements AuthenticationProvider<Securi
         DefaultLdapAuthoritiesPopulator populator = new DefaultLdapAuthoritiesPopulator(contextSource,
                 environment.getProperty("group-search-base", ""));
         populator.setRolePrefix("");
+        populator.setGroupRoleAttribute(environment.getProperty("group-role-attribute", "cn"));
+        populator.setGroupSearchFilter(environment.getProperty("group-search-filter", "(uniqueMember={0})"));
 
         ldapAuthenticationProviderConfigurer.ldapAuthoritiesPopulator(populator).contextSource(contextSource);
 


### PR DESCRIPTION
fix gravitee-io/issues#1700