### PR TITLE
fix: Unable to connect cluster remotely

### DIFF
--- a/gravitee-management-api-standalone/gravitee-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-management-api-standalone/gravitee-management-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -314,9 +314,12 @@ notifiers:
 # Gravitee Alert Engine is only available with support
 alerts:
   enabled: false
-  # Default plugin provided with support
   default:
     enabled: false
-    hazelcast:
-      config:
-        path: ${gravitee.home}/config/hazelcast.xml
+    # must be reachable by other nodes
+    cluster:
+      host: localhost
+      port: 0
+      hazelcast:
+        config:
+          path: ${gravitee.home}/config/hazelcast.xml


### PR DESCRIPTION
This closes gravitee-io/gravitee-alert-engine#22