### PR TITLE
fix(api): Avoid duplicate name for groups and endpoints

### DIFF
--- a/gravitee-management-api-service/src/main/java/io/gravitee/management/service/exceptions/ApiEndpointNameAlreadyExistsException.java
+++ b/gravitee-management-api-service/src/main/java/io/gravitee/management/service/exceptions/ApiEndpointNameAlreadyExistsException.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.management.service.exceptions;
+
+import io.gravitee.common.http.HttpStatusCode;
+
+/**
+ * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class ApiEndpointNameAlreadyExistsException extends AbstractManagementException {
+
+    private final String endpointName;
+
+    public ApiEndpointNameAlreadyExistsException(String endpointName) {
+        this.endpointName = endpointName;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Endpoint names (and group names) must be unique. The name [" + endpointName + "] already exists.";
+    }
+}


### PR DESCRIPTION
fix gravitee-io/issues#1578