### PR TITLE
fix openapi security scheme type formatting

### DIFF
--- a/gravitee-management-api-service/pom.xml
+++ b/gravitee-management-api-service/pom.xml
@@ -25,7 +25,7 @@
 		<swagger.version>1.5.21</swagger.version>
 		<json-patch.version>1.9</json-patch.version>
 		<swagger-compat-spec-parser.version>1.0.34</swagger-compat-spec-parser.version>
-		<swagger-parser.version>2.0.0-SNAPSHOT</swagger-parser.version>
+		<swagger-parser.version>2.0.9</swagger-parser.version>
 	</properties>
 
 	<parent>

--- a/gravitee-management-api-service/src/main/java/io/gravitee/management/service/impl/SwaggerServiceImpl.java
+++ b/gravitee-management-api-service/src/main/java/io/gravitee/management/service/impl/SwaggerServiceImpl.java
@@ -32,8 +32,8 @@ import io.swagger.models.properties.RefProperty;
 import io.swagger.parser.SwaggerCompatConverter;
 import io.swagger.parser.SwaggerParser;
 import io.swagger.parser.util.RemoteUrl;
-import io.swagger.util.Json;
-import io.swagger.util.Yaml;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
@@ -43,6 +43,7 @@ import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import io.swagger.v3.parser.OpenAPIV3Parser;
+import io.swagger.v3.parser.core.models.AuthorizationValue;
 import io.swagger.v3.parser.core.models.SwaggerParseResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,6 +60,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
@@ -150,7 +152,7 @@ public class SwaggerServiceImpl implements SwaggerService {
         if (swaggerDescriptor.getType() == ImportSwaggerDescriptorEntity.Type.INLINE) {
             apiEntity = mapOpenApiToNewApi(new OpenAPIV3Parser().readContents(swaggerDescriptor.getPayload()), swaggerDescriptor.isWithPolicyMocks());
         } else {
-            apiEntity = mapOpenApiToNewApi(new OpenAPIV3Parser().readWithInfo(swaggerDescriptor.getPayload(), null), swaggerDescriptor.isWithPolicyMocks());
+            apiEntity = mapOpenApiToNewApi(new OpenAPIV3Parser().readWithInfo(swaggerDescriptor.getPayload(), (List<AuthorizationValue>) null), swaggerDescriptor.isWithPolicyMocks());
         }
         return apiEntity;
     }

--- a/gravitee-management-api-service/src/test/java/io/gravitee/management/service/SwaggerService_TransformTest.java
+++ b/gravitee-management-api-service/src/test/java/io/gravitee/management/service/SwaggerService_TransformTest.java
@@ -21,8 +21,9 @@ import com.google.common.io.Resources;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.management.model.PageEntity;
 import io.gravitee.management.service.impl.SwaggerServiceImpl;
-import io.swagger.util.Json;
-import io.swagger.util.Yaml;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Yaml;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -127,5 +128,6 @@ public class SwaggerService_TransformTest {
         assertEquals("1.2.3", node.get("info").get("version").asText());
         assertEquals("Gravitee.io Swagger API", node.get("info").get("title").asText());
         assertEquals("https://my.domain.com/v1", node.get("servers").get(0).get("url").asText());
+        assertEquals("oauth2", node.get("components").get("securitySchemes").get("oauth2Scheme").get("type").asText());
     }
 }

--- a/gravitee-management-api-service/src/test/resources/io/gravitee/management/service/openapi.json
+++ b/gravitee-management-api-service/src/test/resources/io/gravitee/management/service/openapi.json
@@ -130,6 +130,20 @@
     }
   },
   "components": {
+    "securitySchemes": {
+      "oauth2Scheme": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://example.com/authorize",
+            "tokenUrl": "https://example.com/token",
+            "scopes": {
+              "user": "simple user rights"
+            }
+          }
+        }
+      }
+    },
     "schemas": {
       "Pet": {
         "required": [

--- a/gravitee-management-api-service/src/test/resources/io/gravitee/management/service/openapi.yaml
+++ b/gravitee-management-api-service/src/test/resources/io/gravitee/management/service/openapi.yaml
@@ -80,6 +80,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 components:
+  securitySchemes:
+    oauth2Scheme:
+      type: oauth2
+      flows:
+        authorizationCode:
+          authorizationUrl: "https://example.com/authorize"
+          tokenUrl: "https://example.com/token"
+          scopes:
+            user: "simple user rights"
   schemas:
     Pet:
       required:

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,6 @@
         </dependency>
     </dependencies>
 
-    <!-- allow snapshot only for openApi until the final release -->
     <build>
         <pluginManagement>
             <plugins>
@@ -321,10 +320,6 @@
                         <rules>
                             <requireReleaseDeps>
                                 <message>No Snapshots Allowed!</message>
-                                <excludes>
-                                    <exclude>io.swagger.core.v3:*</exclude>
-                                    <exclude>io.swagger.parser.v3:*</exclude>
-                                </excludes>
                             </requireReleaseDeps>
                             <requireReleaseVersion>
                                 <message>No Snapshots Allowed!</message>
@@ -335,18 +330,4 @@
             </plugins>
         </pluginManagement>
     </build>
-    <profiles>
-        <profile>
-            <id>allow-snapshots-for-swagger3</id>
-            <activation><activeByDefault>true</activeByDefault></activation>
-            <repositories>
-                <repository>
-                    <id>snapshots-repo</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                    <releases><enabled>false</enabled></releases>
-                    <snapshots><enabled>true</enabled></snapshots>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
Changes:
- I am not sure about why swagger-parser was on a snapshot version here but in order to test this PR I had to set a released version of swagger-parser (2.0.9)
- I changed io.swagger.util.Json and io.swagger.util.Yaml imports to io.swagger.v3.core.util.Json and io.swagger.v3.core.util.Yaml respectively
- The readWithInfo method is ambiguous when used with null value as second parameter, so I had to cast the null parameter to make it work (probably due to swagger-parser update)
- I added a test case in order to check the fixed issue


Fixes https://github.com/gravitee-io/issues/issues/2014