### PR TITLE
fix: Error on duplicate endpoint names when creating via API

### DIFF
--- a/gravitee-management-api-service/src/main/java/io/gravitee/management/service/impl/ApiServiceImpl.java
+++ b/gravitee-management-api-service/src/main/java/io/gravitee/management/service/impl/ApiServiceImpl.java
@@ -166,6 +166,7 @@ public class ApiServiceImpl extends TransactionalService implements ApiService {
         Proxy proxy = new Proxy();
         proxy.setContextPath(newApiEntity.getContextPath());
         EndpointGroup group = new EndpointGroup();
+        group.setName("default-group");
         group.setEndpoints(singleton(new HttpEndpoint("default", newApiEntity.getEndpoint())));
         proxy.setGroups(singleton(group));
         apiEntity.setProxy(proxy);


### PR DESCRIPTION
This closes gravitee-io/issues#2023