### PR TITLE
fix(mail): Escape the content of the HTML templates when used for emails

### DIFF
--- a/gravitee-management-api-rest/src/main/java/io/gravitee/management/rest/spring/EmailConfiguration.java
+++ b/gravitee-management-api-rest/src/main/java/io/gravitee/management/rest/spring/EmailConfiguration.java
@@ -15,8 +15,12 @@
  */
 package io.gravitee.management.rest.spring;
 
+import freemarker.cache.ConditionalTemplateConfigurationFactory;
+import freemarker.cache.FileExtensionMatcher;
 import freemarker.cache.FileTemplateLoader;
+import freemarker.core.HTMLOutputFormat;
 import freemarker.core.TemplateClassResolver;
+import freemarker.core.TemplateConfiguration;
 import io.gravitee.common.util.EnvironmentUtils;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -45,6 +49,8 @@ public class EmailConfiguration {
 
     private final static String EMAIL_PROPERTIES_PREFIX = "email.properties";
     private final static String MAILAPI_PROPERTIES_PREFIX = "mail.smtp.";
+
+    private final static String HTML_TEMPLATE_EXTENSION = "html";
 
     @Value("${email.host}")
     private String host;
@@ -96,6 +102,13 @@ public class EmailConfiguration {
     public freemarker.template.Configuration getConfiguration() {
         final freemarker.template.Configuration configuration =
                 new freemarker.template.Configuration(freemarker.template.Configuration.VERSION_2_3_22);
+
+        TemplateConfiguration tcHTML = new TemplateConfiguration();
+        tcHTML.setOutputFormat(HTMLOutputFormat.INSTANCE);
+
+        configuration.setTemplateConfigurations(
+                new ConditionalTemplateConfigurationFactory(new FileExtensionMatcher(HTML_TEMPLATE_EXTENSION), tcHTML));
+
         try {
             configuration.setNewBuiltinClassResolver(TemplateClassResolver.SAFER_RESOLVER);
             configuration.setTemplateLoader(new FileTemplateLoader(new File(templatesPath)));


### PR DESCRIPTION
Closes gravitee-io/issues#2232