### PR TITLE
Issue #2577: Fix Permissions for assigning an Group to every new API …

### DIFF
--- a/gravitee-management-api-rest/src/main/java/io/gravitee/management/rest/resource/GroupResource.java
+++ b/gravitee-management-api-rest/src/main/java/io/gravitee/management/rest/resource/GroupResource.java
@@ -108,6 +108,7 @@ public class GroupResource extends AbstractResource {
             updateGroupEntity.setLockApplicationRole(groupEntity.isLockApplicationRole());
             updateGroupEntity.setSystemInvitation(groupEntity.isSystemInvitation());
             updateGroupEntity.setEmailInvitation(groupEntity.isEmailInvitation());
+            updateGroupEntity.setEventRules(groupEntity.getEventRules());
             if (groupEntity.isLockApiRole()) {
                 updateGroupEntity.getRoles().put(RoleScope.API, groupEntity.getRoles().get(RoleScope.API));
             }


### PR DESCRIPTION
Secure API Endpoint, that a Group Admin can not set the "Associate to every new API / Associate to every new Application" events without Management Groups Write permissions  [gravitee-io/issues/issues/2577]