### PR TITLE
fix: Renew Subscription also renews expired API keys (not revoked)

### DIFF
--- a/gravitee-management-api-model/src/main/java/io/gravitee/management/model/ApiKeyEntity.java
+++ b/gravitee-management-api-model/src/main/java/io/gravitee/management/model/ApiKeyEntity.java
@@ -50,6 +50,8 @@ public class ApiKeyEntity {
 
     private boolean paused;
 
+    private boolean expired;
+
     public String getKey() {
         return key;
     }
@@ -128,6 +130,14 @@ public class ApiKeyEntity {
 
     public void setPaused(boolean paused) {
         this.paused = paused;
+    }
+
+    public boolean isExpired() {
+        return expired;
+    }
+
+    public void setExpired(boolean expired) {
+        this.expired = expired;
     }
 
     @Override

--- a/gravitee-management-api-service/src/main/java/io/gravitee/management/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-management-api-service/src/main/java/io/gravitee/management/service/impl/ApiKeyServiceImpl.java
@@ -116,7 +116,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
             // Get previously generated keys to set their expiration date
             Set<ApiKey> oldKeys = apiKeyRepository.findBySubscription(subscription);
             for (ApiKey oldKey : oldKeys) {
-                if (! oldKey.equals(newApiKey)) {
+                if (! oldKey.equals(newApiKey) && !convert(oldKey).isExpired()) {
                     setExpiration(expirationDate, oldKey);
                 }
             }
@@ -311,10 +311,10 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
     }
 
     private void setExpiration(Date expirationDate, ApiKey key) throws TechnicalException {
+        final Date now = new Date();
+        key.setUpdatedAt(now);
         if (!key.isRevoked()) {
             ApiKey oldkey = new ApiKey(key);
-
-            key.setUpdatedAt(new Date());
             key.setExpireAt(expirationDate);
             apiKeyRepository.update(key);
 
@@ -331,7 +331,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                     .apikey(key)
                     .plan(plan)
                     .owner(owner);
-            if (key.getExpireAt() != null && new Date().before(key.getExpireAt())) {
+            if (key.getExpireAt() != null && now.before(key.getExpireAt())) {
                 paramsBuilder.expirationDate(key.getExpireAt());
             }
 
@@ -348,7 +348,6 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                     oldkey,
                     key);
         } else {
-            key.setUpdatedAt(new Date());
             apiKeyRepository.update(key);
         }
     }
@@ -359,6 +358,7 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
         apiKeyEntity.setKey(apiKey.getKey());
         apiKeyEntity.setCreatedAt(apiKey.getCreatedAt());
         apiKeyEntity.setExpireAt(apiKey.getExpireAt());
+        apiKeyEntity.setExpired(apiKey.getExpireAt() != null && new Date().after(apiKey.getExpireAt()));
         apiKeyEntity.setRevoked(apiKey.isRevoked());
         apiKeyEntity.setRevokedAt(apiKey.getRevokedAt());
         apiKeyEntity.setUpdatedAt(apiKey.getUpdatedAt());


### PR DESCRIPTION
fix gravitee-io/issues#2578