### PR TITLE
fix: Missing informations on email template for expired api-key

### DIFF
--- a/gravitee-rest-api-management/gravitee-rest-api-management-standalone/gravitee-rest-api-management-standalone-distribution/src/main/resources/templates/apiKeyExpired.html
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-standalone/gravitee-rest-api-management-standalone-distribution/src/main/resources/templates/apiKeyExpired.html
@@ -5,11 +5,10 @@
 		</header>
 		<div style="margin-top: 50px; color: #424e5a;">
 			<h3>Hi,</h3>
-			<#if expirationDate??>
-                <p>The API Key <code>${apiKey}</code> will expire the ${expirationDate?date} at ${expirationDate?time}.
-			<#else>
-				<p>The API Key <code>${apiKey}</code> has expired.
-			</#if>
+			<p>
+				Your API Key <b><code>${apiKey}</code></b> used by subscription to plan <b>${plan.name}</b> for API
+				<b>${api.name}</b> and application <b>${application.name}</b> <#if expirationDate??>will expire the ${expirationDate?date} at ${expirationDate?time}.<#else>has expired.</#if>
+			</p>
 		</p>
 	</body>
 </html>

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-standalone/gravitee-rest-api-portal-standalone-distribution/src/main/resources/templates/apiKeyExpired.html
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-standalone/gravitee-rest-api-portal-standalone-distribution/src/main/resources/templates/apiKeyExpired.html
@@ -5,11 +5,10 @@
 		</header>
 		<div style="margin-top: 50px; color: #424e5a;">
 			<h3>Hi,</h3>
-			<#if expirationDate??>
-                <p>The API Key <code>${apiKey}</code> will expire the ${expirationDate?date} at ${expirationDate?time}.
-			<#else>
-				<p>The API Key <code>${apiKey}</code> has expired.
-			</#if>
+			<p>
+				Your API Key <b><code>${apiKey}</code></b> used by subscription to plan <b>${plan.name}</b> for API
+				<b>${api.name}</b> and application <b>${application.name}</b> <#if expirationDate??>will expire the ${expirationDate?date} at ${expirationDate?time}.<#else>has expired.</#if>
+			</p>
 		</p>
 	</body>
 </html>


### PR DESCRIPTION
fix gravitee-io/issues#3208