### PR TITLE
chore(dependencies): upgrade dependencies

### DIFF
--- a/gravitee-management-api-rest/pom.xml
+++ b/gravitee-management-api-rest/pom.xml
@@ -19,6 +19,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+	<properties>
+		<swagger-jersey2-jaxrs.version>1.6.1</swagger-jersey2-jaxrs.version>
+	</properties>
 
 	<parent>
 		<groupId>io.gravitee.management</groupId>
@@ -69,12 +72,10 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
-			<version>${spring.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>1.18</version>
 		</dependency>
 
 		<!-- Jersey dependencies -->
@@ -100,7 +101,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.ext</groupId>
-			<artifactId>jersey-spring4</artifactId>
+			<artifactId>jersey-spring5</artifactId>
 			<version>${jersey.version}</version>
 			<exclusions>
 				<exclusion>
@@ -118,7 +119,7 @@
 		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-jersey2-jaxrs</artifactId>
-			<version>1.5.23</version>
+			<version>${swagger-jersey2-jaxrs.version}</version>
 		</dependency>
 
 		<!-- Jackson dependencies -->

--- a/gravitee-management-api-services/gravitee-management-api-services-dictionary/pom.xml
+++ b/gravitee-management-api-services/gravitee-management-api-services-dictionary/pom.xml
@@ -32,7 +32,6 @@
 
     <properties>
         <jolt.version>0.1.1</jolt.version>
-        <json-schema-validator.version>2.2.6</json-schema-validator.version>
     </properties>
 
     <dependencies>
@@ -60,13 +59,6 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <!-- Json schema validator -->
-        <dependency>
-            <groupId>com.github.fge</groupId>
-            <artifactId>json-schema-validator</artifactId>
-            <version>${json-schema-validator.version}</version>
         </dependency>
 
         <!-- Spring dependencies -->

--- a/gravitee-management-api-services/gravitee-management-api-services-dynamic-properties/pom.xml
+++ b/gravitee-management-api-services/gravitee-management-api-services-dynamic-properties/pom.xml
@@ -32,7 +32,6 @@
 
     <properties>
         <jolt.version>0.1.1</jolt.version>
-        <json-schema-validator.version>2.2.6</json-schema-validator.version>
     </properties>
 
     <dependencies>
@@ -60,13 +59,6 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <!-- Json schema validator -->
-        <dependency>
-            <groupId>com.github.fge</groupId>
-            <artifactId>json-schema-validator</artifactId>
-            <version>${json-schema-validator.version}</version>
         </dependency>
 
         <!-- Spring dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <name>Gravitee.io APIM - Management</name>
 
     <properties>
+        <spring.version>5.2.5.RELEASE</spring.version>
         <gravitee-node.version>1.6.4</gravitee-node.version>
         <gravitee-definition.version>1.20.0</gravitee-definition.version>
         <gravitee-common.version>1.16.2</gravitee-common.version>
@@ -47,20 +48,24 @@
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <apacheds-server-jndi.version>1.5.5</apacheds-server-jndi.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <jersey.version>2.29</jersey.version>
-        <jetty.version>9.4.20.v20190813</jetty.version>
-        <spring.security.version>5.1.5.RELEASE</spring.security.version>
+        <jersey.version>2.30.1</jersey.version>
+        <jetty.version>9.4.28.v20200408</jetty.version>
+        <spring.security.version>5.2.3.RELEASE</spring.security.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <mail.version>1.4.7</mail.version>
-        <freemarker.version>2.3.28</freemarker.version>
+        <freemarker.version>2.3.30</freemarker.version>
         <java-jwt.version>3.10.2</java-jwt.version>
-        <guava.version>20.0</guava.version>
-        <jsonpath.version>2.3.0</jsonpath.version>
+        <guava.version>29.0-jre</guava.version>
+        <jsonpath.version>2.4.0</jsonpath.version>
         <lucene.version>7.5.0</lucene.version>
         <powermock.version>2.0.0</powermock.version>
         <commons-lang3.version>3.9</commons-lang3.version>
         <swagger.version>1.5.23</swagger.version>
         <nimbus-jose-jwt.version>8.15</nimbus-jose-jwt.version>
+        <spring-integration.version>5.2.5.RELEASE</spring-integration.version>
+        <snakeyaml.version>1.26</snakeyaml.version>
+        <jackson.version>2.10.3</jackson.version>
+        <json-schema-validator.version>2.2.13</json-schema-validator.version>
     </properties>
 
     <modules>
@@ -238,6 +243,11 @@
                 <artifactId>spring-webmvc</artifactId>
                 <version>${spring.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.integration</groupId>
+                <artifactId>spring-integration-xml</artifactId>
+                <version>${spring-integration.version}</version>
+            </dependency>
 
             <!-- JWT -->
             <dependency>
@@ -249,38 +259,34 @@
             <!-- jetty -->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlets</artifactId>
+                <artifactId>jetty-bom</artifactId>
                 <version>${jetty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlet</artifactId>
-                <version>${jetty.version}</version>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-server</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-webapp</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jmx</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-util</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-continuation</artifactId>
-                <version>${jetty.version}</version>
+                <groupId>com.github.java-json-tools</groupId>
+                <artifactId>json-schema-validator</artifactId>
+                <version>${json-schema-validator.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
spring 5.1.3 -> 5.2.5
spring-security 5.1.5 -> 5.2.5
jersey 2.29 -> 2.30.1
jetty 9.4.20 -> 9.4.28
freemarker 2.3.28 -> 2.3.30
guava 20.0 -> 29.0-jre
json-path 2.3.0 -> 2.4.0
snakeyaml 1.18 -> 1.26
jackson 2.9.8 -> 2.10.3
json-schema-validator 2.2.8 -> 2.2.13
swagger-jersey-jaxrs 1.5.23 -> 1.6.1
jersey-spring4 -> jersey-spring5
java-jwt 2.2.1 -> 3.10.2

Closes gravitee-io/issues#3652