### PR TITLE
chore(dependencies): upgrade dependencies

### DIFF
--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/pom.xml
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/pom.xml
@@ -30,6 +30,10 @@
 	<packaging>jar</packaging>
 	<name>Gravitee.io Rest APIs - Management - Rest API</name>
 
+	<properties>
+		<swagger-jersey2-jaxrs.version>1.6.1</swagger-jersey2-jaxrs.version>
+	</properties>
+
 	<dependencies>
 
 		<!-- Gravitee Management dependencies-->
@@ -69,56 +73,39 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
-			<version>${spring.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>1.18</version>
 		</dependency>
 
 		<!-- Jersey dependencies -->
 		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-servlet</artifactId>
-			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-jackson</artifactId>
-			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.ext</groupId>
 			<artifactId>jersey-bean-validation</artifactId>
-			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-multipart</artifactId>
-			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.ext</groupId>
-			<artifactId>jersey-spring4</artifactId>
-			<version>${jersey.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-beans</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-web</artifactId>
-				</exclusion>
-			</exclusions>
+			<artifactId>jersey-spring5</artifactId>
 		</dependency>
 
 		<!-- Swagger -->
 		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-jersey2-jaxrs</artifactId>
-			<version>1.5.21</version>
+			<version>${swagger-jersey2-jaxrs.version}</version>
 		</dependency>
 
 		<dependency>

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/pom.xml
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/pom.xml
@@ -126,49 +126,32 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-beans</artifactId>
-			<version>${spring.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
-			<version>1.18</version>
 		</dependency>
 
 		<!-- Jersey dependencies -->
 		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-servlet</artifactId>
-			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-jackson</artifactId>
-			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.ext</groupId>
 			<artifactId>jersey-bean-validation</artifactId>
-			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-multipart</artifactId>
-			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.ext</groupId>
-			<artifactId>jersey-spring4</artifactId>
-			<version>${jersey.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-beans</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.springframework</groupId>
-					<artifactId>spring-web</artifactId>
-				</exclusion>
-			</exclusions>
+			<artifactId>jersey-spring5</artifactId>
 		</dependency>
 
 		<dependency>
@@ -181,17 +164,14 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>${jackson.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>${jackson.version}</version>
 		</dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
 
 		<!-- Image processing -->

--- a/gravitee-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/healthcheck/AnalyticsRepositoryProbe.java
+++ b/gravitee-rest-api-repository/src/main/java/io/gravitee/rest/api/repository/healthcheck/AnalyticsRepositoryProbe.java
@@ -20,10 +20,7 @@ import io.gravitee.node.api.healthcheck.Result;
 import io.gravitee.repository.analytics.api.AnalyticsRepository;
 import io.gravitee.repository.analytics.query.count.CountQuery;
 import io.gravitee.rest.api.repository.vertx.VertxCompletableFuture;
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
+import io.vertx.core.*;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -50,9 +47,9 @@ public class AnalyticsRepositoryProbe implements Probe {
     public CompletableFuture<Result> check() {
         Future<Result> future = Future.future();
 
-        vertx.executeBlocking(new Handler<Future<Result>>() {
+        vertx.executeBlocking(new Handler<Promise<Result>>() {
             @Override
-            public void handle(Future<Result> event) {
+            public void handle(Promise<Result> event) {
                 try {
                     analyticsRepository.query(new CountQuery());
                     event.complete(Result.healthy());

--- a/gravitee-rest-api-service/pom.xml
+++ b/gravitee-rest-api-service/pom.xml
@@ -147,7 +147,6 @@
 		<dependency>
 			<groupId>org.freemarker</groupId>
 			<artifactId>freemarker</artifactId>
-			<version>${freemarker.version}</version>
 		</dependency>
 
 		<!-- HTML Parser -->

--- a/gravitee-rest-api-services/gravitee-rest-api-services-dictionary/pom.xml
+++ b/gravitee-rest-api-services/gravitee-rest-api-services-dictionary/pom.xml
@@ -32,7 +32,6 @@
 
     <properties>
         <jolt.version>0.1.1</jolt.version>
-        <json-schema-validator.version>2.2.6</json-schema-validator.version>
     </properties>
 
     <dependencies>
@@ -60,13 +59,6 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <!-- Json schema validator -->
-        <dependency>
-            <groupId>com.github.fge</groupId>
-            <artifactId>json-schema-validator</artifactId>
-            <version>${json-schema-validator.version}</version>
         </dependency>
 
         <!-- Spring dependencies -->

--- a/gravitee-rest-api-services/gravitee-rest-api-services-dynamic-properties/pom.xml
+++ b/gravitee-rest-api-services/gravitee-rest-api-services-dynamic-properties/pom.xml
@@ -32,7 +32,6 @@
 
     <properties>
         <jolt.version>0.1.1</jolt.version>
-        <json-schema-validator.version>2.2.6</json-schema-validator.version>
     </properties>
 
     <dependencies>
@@ -60,13 +59,6 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-
-        <!-- Json schema validator -->
-        <dependency>
-            <groupId>com.github.fge</groupId>
-            <artifactId>json-schema-validator</artifactId>
-            <version>${json-schema-validator.version}</version>
         </dependency>
 
         <!-- Spring dependencies -->

--- a/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/gravitee-rest-api-standalone-distribution-zip/pom.xml
+++ b/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/gravitee-rest-api-standalone-distribution-zip/pom.xml
@@ -31,6 +31,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
+		<!--suppress UnresolvedMavenProperty -->
 		<gravitee.management.log.dir>${gravitee.home}/logs</gravitee.management.log.dir>
 	</properties>
 	

--- a/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/pom.xml
+++ b/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/pom.xml
@@ -102,14 +102,6 @@
 
 		<dependency>
 			<groupId>io.gravitee.rest.api.services</groupId>
-            <artifactId>gravitee-rest-api-services-search-indexer</artifactId>
-			<version>${project.version}</version>
-			<scope>runtime</scope>
-			<type>zip</type>
-		</dependency>
-
-		<dependency>
-			<groupId>io.gravitee.rest.api.services</groupId>
 			<artifactId>gravitee-rest-api-services-sync</artifactId>
 			<version>${project.version}</version>
 			<scope>runtime</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.gravitee</groupId>
         <artifactId>gravitee-parent</artifactId>
-        <version>17.1</version>
+        <version>19-SNAPSHOT</version>
     </parent>
 
     <groupId>io.gravitee.rest.api</groupId>
@@ -47,19 +47,22 @@
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <apacheds-server-jndi.version>1.5.5</apacheds-server-jndi.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
-        <jersey.version>2.29</jersey.version>
-        <jetty.version>9.4.20.v20190813</jetty.version>
-        <spring.security.version>5.1.5.RELEASE</spring.security.version>
+        <spring.security.version>5.3.1.RELEASE</spring.security.version>
         <validation-api.version>2.0.1.Final</validation-api.version>
         <mail.version>1.4.7</mail.version>
-        <freemarker.version>2.3.28</freemarker.version>
+        <freemarker.version>2.3.30</freemarker.version>
         <java-jwt.version>2.2.1</java-jwt.version>
-        <guava.version>20.0</guava.version>
-        <jsonpath.version>2.3.0</jsonpath.version>
+        <guava.version>29.0-jre</guava.version>
+        <jsonpath.version>2.4.0</jsonpath.version>
         <lucene.version>7.5.0</lucene.version>
         <powermock.version>2.0.0</powermock.version>
         <commons-lang3.version>3.9</commons-lang3.version>
-        <swagger.version>1.5.23</swagger.version>
+        <swagger.version>1.6.1</swagger.version>
+        <nimbus-jose-jwt.version>8.15</nimbus-jose-jwt.version>
+        <spring-integration.version>5.2.5.RELEASE</spring-integration.version>
+        <snakeyaml.version>1.26</snakeyaml.version>
+        <jackson.version>2.10.3</jackson.version>
+        <json-schema-validator.version>2.2.13</json-schema-validator.version>
     </properties>
 
     <modules>
@@ -238,6 +241,11 @@
                 <artifactId>spring-webmvc</artifactId>
                 <version>${spring.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.springframework.integration</groupId>
+                <artifactId>spring-integration-xml</artifactId>
+                <version>${spring-integration.version}</version>
+            </dependency>
 
             <!-- JWT -->
             <dependency>
@@ -246,41 +254,32 @@
                 <version>${java-jwt.version}</version>
             </dependency>
 
-            <!-- jetty -->
             <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlets</artifactId>
-                <version>${jetty.version}</version>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-servlet</artifactId>
-                <version>${jetty.version}</version>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${guava.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-server</artifactId>
-                <version>${jetty.version}</version>
+                <groupId>com.fasterxml.jackson</groupId>
+                <artifactId>jackson-bom</artifactId>
+                <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-webapp</artifactId>
-                <version>${jetty.version}</version>
+                <groupId>com.github.java-json-tools</groupId>
+                <artifactId>json-schema-validator</artifactId>
+                <version>${json-schema-validator.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jmx</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-util</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-continuation</artifactId>
-                <version>${jetty.version}</version>
+                <groupId>org.freemarker</groupId>
+                <artifactId>freemarker</artifactId>
+                <version>${freemarker.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Note: depends on https://github.com/gravitee-io/gravitee-parent/pull/17

spring 5.1.3 -> 5.2.6
spring-security 5.1.5 -> 5.3.1
netty 4.1.42 -> 4.1.49
jetty 9.4.20 -> 9.4.28
jersey 2.29 -> 2.30.1
jackson 2.9.8 -> 2.10.3
rxjava2 2.2.17 -> 2.2.19
swagger-jersey2-jaxrs 1.5.21 -> 1.6.1
swagger 1.5.23 -> 1.6.1
snakeyaml 1.18 -> 1.26
json-path 2.3.0 -> 2.4.0
guava 20.0 -> 29.0-jre
jackson 2.9.8 -> 2.10.3
nimbus 7.1 -> 8.15
freemarker 2.3.28 -> 2.3.30

Closes gravitee-io/issues#3777