### PR TITLE
fix(portal): order top APIs with specific order and not by name

### DIFF
--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApisResource.java
@@ -159,12 +159,13 @@ public class ApisResource extends AbstractResource {
     }
 
     private FilteredApi getTopApis(Collection<ApiEntity> apis, boolean excluded) {
-        List<String> topApiIdList = topApiService.findAll().stream().map(TopApiEntity::getApi).collect(Collectors.toList());
+        Map<String, Integer> topApiIdAndOrderMap = topApiService.findAll().stream().collect(Collectors.toMap(TopApiEntity::getApi, TopApiEntity::getOrder));
+        
         return new FilteredApi(
                 apis.stream()
-                    .filter(api-> (!excluded && topApiIdList.contains(api.getId())) ||
-                            (excluded && !topApiIdList.contains(api.getId())) )
-                    .sorted((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(o1.getName(), o2.getName()))
+                    .filter(api-> (!excluded && topApiIdAndOrderMap.keySet().contains(api.getId())) ||
+                            (excluded && !topApiIdAndOrderMap.keySet().contains(api.getId())) )
+                    .sorted((o1, o2) -> topApiIdAndOrderMap.get(o1.getId()).compareTo(topApiIdAndOrderMap.get(o2.getId())))
                     .collect(Collectors.toList())
                 , null
                 );

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceTest.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApisResourceTest.java
@@ -270,8 +270,10 @@ public class ApisResourceTest extends AbstractResourceTest {
     public void shouldGetFeaturedApis() {
         TopApiEntity topApi5 = new TopApiEntity();
         topApi5.setApi("5");
+        topApi5.setOrder(1);
         TopApiEntity topApi6 = new TopApiEntity();
         topApi6.setApi("6");
+        topApi6.setOrder(2);
         doReturn(Arrays.asList(topApi5, topApi6)).when(topApiService).findAll();
 
         final Response response = target().queryParam("cat", "FEATURED").request().get();


### PR DESCRIPTION
Fixes gravitee-io/issues#3801