### PR TITLE
feat(security): add recaptcha and csrf support on portal

### DIFF
--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/mapper/ConfigurationMapper.java
@@ -46,6 +46,7 @@ public class ConfigurationMapper {
         configuration.setPlan(convert(configEntity.getPlan()));
         configuration.setPortal(convert(configEntity.getPortal(), configEntity.getApplication()));
         configuration.setScheduler(convert(configEntity.getScheduler()));
+        configuration.setRecaptcha(convert(configEntity.getReCaptcha()));
         return configuration;
     }
 
@@ -200,6 +201,13 @@ public class ConfigurationMapper {
     private ConfigurationAnalytics convert(Analytics analytics) {
         ConfigurationAnalytics configuration = new ConfigurationAnalytics();
         configuration.setClientTimeout(analytics.getClientTimeout());
+        return configuration;
+    }
+
+    private ConfigurationReCaptcha convert(ReCaptcha reCaptcha) {
+        ConfigurationReCaptcha configuration = new ConfigurationReCaptcha();
+        configuration.setEnabled(reCaptcha.getEnabled());
+        configuration.setSiteKey(reCaptcha.getSiteKey());
         return configuration;
     }
 

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/resources/openapi.yaml
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/resources/openapi.yaml
@@ -3548,6 +3548,8 @@ components:
           $ref: '#/components/schemas/ConfigurationAnalytics'
         application:
           $ref: '#/components/schemas/ConfigurationApplication'
+        recaptcha:
+          $ref: '#/components/schemas/ConfigurationReCaptcha'
     ConfigurationCompany:
       properties:
         name:
@@ -3708,6 +3710,14 @@ components:
           $ref: '#/components/schemas/Enabled'
         backend_to_backend:
           $ref: '#/components/schemas/Enabled'
+    ConfigurationReCaptcha:
+      properties:
+        enabled:
+          description: flag indication if recaptcha is enabled or not
+          type: boolean
+        siteKey:
+          description: reCaptcha site key
+          type: string
 
     CategorizedLinks:
       properties:

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/expectedPortalConfiguration.json
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/expectedPortalConfiguration.json
@@ -111,5 +111,9 @@
         "enabled" : true
       }
     }
+  },
+  "recaptcha" : {
+    "enabled" : true,
+    "siteKey" : "testSiteKey"
   }
 }

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/portalConfigEntity.json
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/resources/io/gravitee/rest/api/portal/rest/mapper/portalConfigEntity.json
@@ -135,5 +135,9 @@
         "enabled" : true
       }
     }
+  },
+  "reCaptcha": {
+    "enabled": true,
+    "siteKey": "testSiteKey"
   }
 }

--- a/gravitee-rest-api-security/src/main/java/io/gravitee/rest/api/security/filter/RecaptchaFilter.java
+++ b/gravitee-rest-api-security/src/main/java/io/gravitee/rest/api/security/filter/RecaptchaFilter.java
@@ -44,7 +44,7 @@ public class RecaptchaFilter extends GenericFilterBean {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RecaptchaFilter.class);
     public static final String DEFAULT_RECAPTCHA_HEADER_NAME = "X-Recaptcha-Token";
-    private static final Set<String> RESTRICTED_PATHS = new HashSet<>(Arrays.asList("/user/login", "/users/registration", "/users/registration/finalize"));
+    private static final Set<String> RESTRICTED_PATHS = new HashSet<>(Arrays.asList("/user/login", "/users/registration", "/users/registration/finalize", "/auth/login", "/users/_reset_password"));
 
     private ReCaptchaService reCaptchaService;
     private ObjectMapper objectMapper;

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ReCaptchaServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ReCaptchaServiceImpl.java
@@ -44,10 +44,10 @@ public class ReCaptchaServiceImpl implements ReCaptchaService {
     @Value("${reCaptcha.enabled:false}")
     private boolean enabled;
 
-    @Value("${reCaptcha.siteKey}")
+    @Value("${reCaptcha.siteKey:}")
     private String siteKey;
 
-    @Value("${reCaptcha.secretKey}")
+    @Value("${reCaptcha.secretKey:}")
     private String secretKey;
 
     @Value("${reCaptcha.minScore:0.5}")

--- a/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -61,9 +61,9 @@ http:
     #allow-methods: 'OPTIONS, GET, POST, PUT, DELETE'
     # Which headers to allow (default values: Cache-Control, Pragma, Origin, Authorization, Content-Type, X-Requested-With, If-Match, X-Xsrf-Token)
     #allow-headers: 'X-Requested-With'
-  #csrf:
-    # Allows to enable or disable the CSRF protection (default is disabled).
-  #  enabled: false
+  csrf:
+    # Allows to enable or disable the CSRF protection. Enabled by default.
+    enabled: true
   hsts:
     enabled: true
     include-sub-domains: true
@@ -332,18 +332,20 @@ user:
   # Password complexity validation policy
   # Applications should enforce password complexity rules to discourage easy to guess passwords.
   # Passwords should require a minimum level of complexity that makes sense for the application and its user population.
-  #password:
-  #  policy:
-  #    pattern: ^(?=\s*\S).*$ # Regex pattern for password validation (default to ^(?=\s*\S).*$ (non empty string))
-  # Example : ^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=])(?=\S+$).{8,}$
-  # ^                # start-of-string
-  #(?=.*[0-9])       # a digit must occur at least once
-  #(?=.*[a-z])       # a lower case letter must occur at least once
-  #(?=.*[A-Z])       # an upper case letter must occur at least once
-  #(?=.*[@#$%^&+=])  # a special character must occur at least once
-  #(?=\S+$)          # no whitespace allowed in the entire string
-  #.{8,}             # anything, at least eight places though
-  #$                 # end-of-string
+  password:
+    policy:
+      # Regex pattern for password validation (default to OWASP recommendations).
+      # 8 to 32 characters, no more than 2 consecutive equal characters, min 1 special characters (@ & # ...), min 1 upper case character.
+      pattern: ^(?:(?=.*\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))(?!.*(.)\1{2,})[A-Za-z0-9!~<>,;:_\-=?*+#."'&§`£€%°()\\\|\[\]\-\$\^\@\/]{8,32}$
+              # Example : ^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[@#$%^&+=])(?=\S+$).{8,}$
+              # ^                # start-of-string
+              #(?=.*[0-9])       # a digit must occur at least once
+              #(?=.*[a-z])       # a lower case letter must occur at least once
+              #(?=.*[A-Z])       # an upper case letter must occur at least once
+              #(?=.*[@#$%^&+=])  # a special character must occur at least once
+              #(?=\S+$)          # no whitespace allowed in the entire string
+              #.{8,}             # anything, at least eight places though
+              #$                 # end-of-string
   creation:
     token:
       #expire-after: 86400
@@ -357,10 +359,10 @@ user:
 # The portal URL used in emails
 portalURL: http://localhost:3000/
 
-# Enable / disable documentation sanitize. Disabled by default.
-#documentation:
-#  markdown:
-#    sanitize: false
+# Enable / disable documentation sanitize. Enabled by default.
+documentation:
+  markdown:
+    sanitize: true
 
 #imports:
   # Enable / disable import from private hosts. Enabled by default. (See https://en.wikipedia.org/wiki/Private_network)


### PR DESCRIPTION
Enable CRSF by default.
Enable default password policy following owasp requirements.
Enable pages html sanitizer.

Closes gravitee-io/issues#3668