### PR TITLE
fix: Node cannot start on an empty database in some context

### DIFF
--- a/gravitee-rest-api-service/pom.xml
+++ b/gravitee-rest-api-service/pom.xml
@@ -194,6 +194,10 @@
 					<groupId>io.swagger</groupId>
 					<artifactId>swagger-core</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>com.github.fge</groupId>
+					<artifactId>json-patch</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 


### PR DESCRIPTION
fix gravitee-io/issues#4118