### PR TITLE
fix(api): Ensure that a final unpublish event is send when an API is deleted

### DIFF
--- a/gravitee-management-api-service/src/main/java/io/gravitee/management/service/impl/ApiServiceImpl.java
+++ b/gravitee-management-api-service/src/main/java/io/gravitee/management/service/impl/ApiServiceImpl.java
@@ -1016,6 +1016,16 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 eventService.search(query)
                         .forEach(event -> eventService.delete(event.getId()));
 
+                // https://github.com/gravitee-io/issues/issues/4130
+                // Ensure we are sending a last UNPUBLISH_API event because the gateway couldn't be aware that the API (and
+                // all its relative events) have been deleted.
+                Map<String, String> properties = new HashMap<>(2);
+                properties.put(Event.EventProperties.API_ID.getValue(), apiId);
+                if (getAuthenticatedUser() != null) {
+                    properties.put(Event.EventProperties.USER.getValue(), getAuthenticatedUser().getUsername());
+                }
+                eventService.create(EventType.UNPUBLISH_API, null, properties);
+
                 // Delete pages
                 final List<PageEntity> pages = pageService.search(new PageQuery.Builder().api(apiId).build());
                 pages.forEach(pageEntity -> pageService.delete(pageEntity.getId()));


### PR DESCRIPTION
Closes gravitee-io/issues#4338