### PR TITLE
Improve generation of swagger definition

### DIFF
--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AbstractResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AbstractResource.java
@@ -117,7 +117,7 @@ public abstract class AbstractResource {
         return Stream.concat(streamUserMembership, streamGroupMembership);
     }
 
-    protected void canReadAPI(final String api) {
+    protected void canReadApi(final String api) {
         if (!isAdmin()) {
             // get memberships of the current user
             List<MembershipEntity> memberships = retrieveApiMembership().collect(Collectors.toList());

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AlertsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AlertsResource.java
@@ -41,7 +41,7 @@ public class AlertsResource extends AbstractResource {
     @GET
     @ApiOperation(value = "List alert metrics")
     @Produces(MediaType.APPLICATION_JSON)
-    public List<AlertMetric> listMetrics() {
+    public List<AlertMetric> getAlertMetrics() {
         return stream(MetricType.values()).map(metric -> {
             final AlertMetric alertMetric = new AlertMetric();
             alertMetric.setKey(metric.name().toLowerCase());

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiAlertsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiAlertsResource.java
@@ -25,12 +25,9 @@ import io.gravitee.rest.api.model.alert.*;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.AlertService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
+import io.swagger.annotations.*;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -47,8 +44,13 @@ import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
 @Api(tags = {"API Alerts"})
 public class ApiAlertsResource extends AbstractResource {
 
-    @Autowired
+    @Inject
     private AlertService alertService;
+
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
 
     @GET
     @ApiOperation(value = "List alerts of an API",
@@ -60,7 +62,7 @@ public class ApiAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = API_ALERT, acls = READ)
     })
-    public List<AlertTriggerEntity> list(@PathParam("api") String api) {
+    public List<AlertTriggerEntity> getApiAlerts() {
         return alertService.findByReference(API, api);
     }
 
@@ -75,7 +77,7 @@ public class ApiAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ALERT, acls = READ)
     })
-    public AlertStatusEntity status(@PathParam("api") String api) {
+    public AlertStatusEntity getApiAlertsStatus() {
         return alertService.getStatus();
     }
 
@@ -90,7 +92,7 @@ public class ApiAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_ALERT, acls = RolePermissionAction.CREATE)
     })
-    public AlertTriggerEntity create(@PathParam("api") String api, @Valid @NotNull final NewAlertTriggerEntity alertEntity) {
+    public AlertTriggerEntity createApiAlert(@Valid @NotNull final NewAlertTriggerEntity alertEntity) {
         alertEntity.setReferenceType(API);
         alertEntity.setReferenceId(api);
         return alertService.create(alertEntity);
@@ -108,7 +110,7 @@ public class ApiAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_ALERT, acls = RolePermissionAction.UPDATE)
     })
-    public AlertTriggerEntity update(@PathParam("api") String api, @PathParam("alert") String alert, @Valid @NotNull final UpdateAlertTriggerEntity alertEntity) {
+    public AlertTriggerEntity updateApiAlert(@PathParam("alert") String alert, @Valid @NotNull final UpdateAlertTriggerEntity alertEntity) {
         alertEntity.setId(alert);
         alertEntity.setReferenceType(API);
         alertEntity.setReferenceId(api);
@@ -126,10 +128,10 @@ public class ApiAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_ALERT, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("api") String api, @PathParam("alert") String alert) {
+    public void deleteApiAlert(@PathParam("alert") String alert) {
         alertService.delete(alert, api);
     }
-    
+
     @GET
     @Path("{alert}/events")
     @ApiOperation(value = "Retrieve the list of events for an alert",
@@ -141,7 +143,7 @@ public class ApiAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ALERT, acls = READ)
     })
-    public Page<AlertEventEntity> listEvents(@PathParam("api") String api, @PathParam("alert") String alert, @BeanParam AlertEventSearchParam param) {
+    public Page<AlertEventEntity> getApiAlertEvents(@PathParam("alert") String alert, @BeanParam AlertEventSearchParam param) {
         return alertService.findEvents(
                 alert,
                 new AlertEventQuery.Builder()

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiAnalyticsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiAnalyticsResource.java
@@ -26,10 +26,7 @@ import io.gravitee.rest.api.model.analytics.query.*;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.AnalyticsService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.BeanParam;
@@ -53,6 +50,11 @@ public class ApiAnalyticsResource extends AbstractResource {
     @Inject
     private AnalyticsService analyticsService;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Get API analytics",
@@ -63,14 +65,12 @@ public class ApiAnalyticsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_ANALYTICS, acls = RolePermissionAction.READ)
     })
-    public Response hits(
-            @PathParam("api") String api,
-            @BeanParam AnalyticsParam analyticsParam) {
+    public Response getApiAnalyticsHits(@BeanParam AnalyticsParam analyticsParam) {
         analyticsParam.validate();
 
         Analytics analytics = null;
 
-        switch(analyticsParam.getType()) {
+        switch (analyticsParam.getType()) {
             case DATE_HISTO:
                 analytics = executeDateHisto(api, analyticsParam);
                 break;

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiAuditResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiAuditResource.java
@@ -18,17 +18,17 @@ package io.gravitee.rest.api.management.rest.resource;
 import io.gravitee.common.data.domain.MetadataPage;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.repository.management.model.Audit;
+import io.gravitee.rest.api.management.rest.resource.param.AuditParam;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.audit.AuditEntity;
 import io.gravitee.rest.api.model.audit.AuditQuery;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.management.rest.resource.param.AuditParam;
-import io.gravitee.rest.api.management.rest.security.Permission;
-import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.service.AuditService;
 import io.swagger.annotations.Api;
-
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import org.reflections.Reflections;
 
 import javax.inject.Inject;
@@ -48,6 +48,11 @@ public class ApiAuditResource extends AbstractResource {
     @Inject
     private AuditService auditService;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
+
     @GET
     @ApiOperation(value = "Retrieve audit logs for the API",
             notes = "User must have the API_AUDIT[READ] permission to use this service")
@@ -56,8 +61,7 @@ public class ApiAuditResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_AUDIT, acls = RolePermissionAction.READ)
     })
-    public MetadataPage<AuditEntity> list(@PathParam("api") String api,
-                                          @BeanParam AuditParam param) {
+    public MetadataPage<AuditEntity> getApiAudits(@BeanParam AuditParam param) {
 
         AuditQuery query = new AuditQuery();
         query.setFrom(param.getFrom());
@@ -83,7 +87,7 @@ public class ApiAuditResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_AUDIT, acls = RolePermissionAction.READ)
     })
-    public Response getEvents(@PathParam("api") String api) {
+    public Response getApiAuditEvents() {
         if (events.isEmpty()) {
             Set<Class<? extends Audit.ApiAuditEvent>> subTypesOf =
                     new Reflections("io.gravitee.repository.management.model")

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiEventsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiEventsResource.java
@@ -16,13 +16,13 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.resource.param.EventTypeListParam;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.EventEntity;
 import io.gravitee.rest.api.model.EventQuery;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.management.rest.resource.param.EventTypeListParam;
-import io.gravitee.rest.api.management.rest.security.Permission;
-import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.service.EventService;
 import io.swagger.annotations.*;
 
@@ -41,7 +41,12 @@ public class ApiEventsResource extends AbstractResource {
 
     @Inject
     private EventService eventService;
-    
+
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Get API's events",
@@ -52,9 +57,7 @@ public class ApiEventsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_EVENT, acls = RolePermissionAction.READ)
     })
-    public List<EventEntity> events(
-            @PathParam("api") String api,
-            @ApiParam @DefaultValue("all") @QueryParam("type") EventTypeListParam eventTypeListParam) {
+    public List<EventEntity> getApiEventsEvents(@ApiParam @DefaultValue("all") @QueryParam("type") EventTypeListParam eventTypeListParam) {
         final EventQuery query = new EventQuery();
         query.setApi(api);
         return eventService.search(query).stream()

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiHeaderResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiHeaderResource.java
@@ -27,8 +27,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -40,7 +40,7 @@ import javax.ws.rs.*;
 @Api(tags = {"Configuration"})
 public class ApiHeaderResource extends AbstractResource {
 
-    @Autowired
+    @Inject
     private ApiHeaderService apiHeaderService;
 
     @PUT
@@ -55,7 +55,7 @@ public class ApiHeaderResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_API_HEADER, acls = RolePermissionAction.UPDATE)
     })
-    public ApiHeaderEntity update(@PathParam("id") String id, @Valid @NotNull final UpdateApiHeaderEntity updateApiHeaderEntity) {
+    public ApiHeaderEntity updateApiHeader(@PathParam("id") String id, @Valid @NotNull final UpdateApiHeaderEntity updateApiHeaderEntity) {
         updateApiHeaderEntity.setId(id);
         return apiHeaderService.update(updateApiHeaderEntity);
     }
@@ -71,7 +71,7 @@ public class ApiHeaderResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_API_HEADER, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("id") String id) {
+    public void deleteApiHeader(@PathParam("id") String id) {
         apiHeaderService.delete(id);
     }
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiHeadersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiHeadersResource.java
@@ -27,8 +27,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -47,7 +47,8 @@ public class ApiHeadersResource extends AbstractResource {
 
     @Context
     private ResourceContext resourceContext;
-    @Autowired
+
+    @Inject
     private ApiHeaderService apiHeaderService;
 
     @GET
@@ -59,7 +60,7 @@ public class ApiHeadersResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_API_HEADER, acls = RolePermissionAction.READ)
     })
-    public List<ApiHeaderEntity> get() {
+    public List<ApiHeaderEntity> getApiHeaders() {
         return apiHeaderService.findAll();
     }
 
@@ -74,7 +75,7 @@ public class ApiHeadersResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_API_HEADER, acls = RolePermissionAction.CREATE)
     })
-    public ApiHeaderEntity create(@Valid @NotNull final NewApiHeaderEntity newApiHeaderEntity) {
+    public ApiHeaderEntity createApiHeader(@Valid @NotNull final NewApiHeaderEntity newApiHeaderEntity) {
         return apiHeaderService.create(newApiHeaderEntity);
     }
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiHealthResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiHealthResource.java
@@ -31,10 +31,7 @@ import io.gravitee.rest.api.model.healthcheck.SearchLogResponse;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.HealthCheckService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
@@ -54,14 +51,18 @@ public class ApiHealthResource extends AbstractResource {
     @Inject
     private HealthCheckService healthCheckService;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation("Health-check statistics for API")
     @Permissions({
             @Permission(value = RolePermission.API_HEALTH, acls = RolePermissionAction.READ)
     })
-    public Response health(
-            @PathParam("api") String api,
+    public Response getApiHealth(
             @QueryParam("type") @DefaultValue("availability") HealthcheckTypeParam healthcheckTypeParam,
             @QueryParam("field") @DefaultValue("endpoint") HealthcheckFieldParam healthcheckFieldParam) {
 
@@ -80,8 +81,7 @@ public class ApiHealthResource extends AbstractResource {
             @Permission(value = RolePermission.API_HEALTH, acls = RolePermissionAction.READ)
     })
     @Path("/average")
-    public Response healthAverage(
-            @PathParam("api") String api,
+    public Response getApiHealthAverage(
             @BeanParam AnalyticsAverageParam analyticsAverageParam) {
         return Response.ok(executeDateHisto(api, analyticsAverageParam)).build();
     }
@@ -125,8 +125,7 @@ public class ApiHealthResource extends AbstractResource {
             @ApiResponse(code = 200, message = "API logs"),
             @ApiResponse(code = 500, message = "Internal server error")})
     @Permissions({@Permission(value = RolePermission.API_HEALTH, acls = RolePermissionAction.READ)})
-    public SearchLogResponse healthcheckLogs(
-            @PathParam("api") String api,
+    public SearchLogResponse getApiHealthCheckLogs(
             @BeanParam LogsParam param) {
 
         param.validate();
@@ -149,8 +148,7 @@ public class ApiHealthResource extends AbstractResource {
             @ApiResponse(code = 200, message = "Single health-check log"),
             @ApiResponse(code = 500, message = "Internal server error")})
     @Permissions({@Permission(value = RolePermission.API_HEALTH, acls = RolePermissionAction.READ)})
-    public Log healthcheckLog(
-            @PathParam("api") String api,
+    public Log getApiHealthCheckLog(
             @PathParam("log") String logId) {
 
         return healthCheckService.findLog(logId);

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiKeysResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiKeysResource.java
@@ -16,11 +16,11 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.ApiKeyEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.management.rest.security.Permission;
-import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.service.ApiKeyService;
 import io.swagger.annotations.*;
 
@@ -46,6 +46,11 @@ public class ApiKeysResource extends AbstractResource {
     @Inject
     private ApiKeyService apiKeyService;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
+
     @DELETE
     @Path("{key}")
     @Produces(MediaType.APPLICATION_JSON)
@@ -55,7 +60,6 @@ public class ApiKeysResource extends AbstractResource {
             @Permission(value = RolePermission.API_SUBSCRIPTION, acls = RolePermissionAction.DELETE)
     })
     public Response revokeApiKey(
-            @PathParam("api") @ApiParam("The API id") String api,
             @PathParam("key") @ApiParam("The API key") String apiKey) {
         apiKeyService.revoke(apiKey, true);
 
@@ -78,7 +82,6 @@ public class ApiKeysResource extends AbstractResource {
             @Permission(value = RolePermission.API_SUBSCRIPTION, acls = RolePermissionAction.UPDATE)
     })
     public Response updateApiKey(
-            @PathParam("api") @ApiParam("The API id") String api,
             @PathParam("key") @ApiParam("The API key") String apiKey,
             @Valid @NotNull ApiKeyEntity apiKeyEntity) {
         if (apiKeyEntity.getKey() != null && ! apiKey.equals(apiKeyEntity.getKey())) {

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiLogsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiLogsResource.java
@@ -16,19 +16,16 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.resource.param.LogsParam;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.analytics.query.LogQuery;
 import io.gravitee.rest.api.model.log.ApiRequest;
 import io.gravitee.rest.api.model.log.SearchLogResponse;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.management.rest.resource.param.LogsParam;
-import io.gravitee.rest.api.management.rest.security.Permission;
-import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.service.LogsService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
@@ -48,6 +45,11 @@ public class ApiLogsResource extends AbstractResource {
     @Inject
     private LogsService logsService;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Get API logs")
@@ -55,8 +57,7 @@ public class ApiLogsResource extends AbstractResource {
             @ApiResponse(code = 200, message = "API logs"),
             @ApiResponse(code = 500, message = "Internal server error")})
     @Permissions({@Permission(value = RolePermission.API_LOG, acls = RolePermissionAction.READ)})
-    public SearchLogResponse apiLogs(
-            @PathParam("api") String api,
+    public SearchLogResponse getApiLogs(
             @BeanParam LogsParam param) {
 
         param.validate();
@@ -81,8 +82,7 @@ public class ApiLogsResource extends AbstractResource {
             @ApiResponse(code = 200, message = "Single log"),
             @ApiResponse(code = 500, message = "Internal server error")})
     @Permissions({@Permission(value = RolePermission.API_LOG, acls = RolePermissionAction.READ)})
-    public ApiRequest apiLog(
-            @PathParam("api") String api,
+    public ApiRequest getApiLog(
             @PathParam("log") String logId,
             @QueryParam("timestamp") Long timestamp) {
         return logsService.findApiLog(logId, timestamp);
@@ -96,10 +96,8 @@ public class ApiLogsResource extends AbstractResource {
             @ApiResponse(code = 200, message = "API logs as CSV"),
             @ApiResponse(code = 500, message = "Internal server error")})
     @Permissions({@Permission(value = RolePermission.API_LOG, acls = RolePermissionAction.READ)})
-    public Response exportAPILogsAsCSV(
-            @PathParam("api") String api,
-            @BeanParam LogsParam param) {
-        final SearchLogResponse searchLogResponse = apiLogs(api, param);
+    public Response exportApiLogsAsCSV(@BeanParam LogsParam param) {
+        final SearchLogResponse searchLogResponse = getApiLogs(param);
         return Response
                 .ok(logsService.exportAsCsv(searchLogResponse))
                 .header(HttpHeaders.CONTENT_DISPOSITION, format("attachment;filename=logs-%s-%s.csv", api, System.currentTimeMillis()))

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMediaResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMediaResource.java
@@ -26,10 +26,7 @@ import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.security.utils.ImageUtils;
 import io.gravitee.rest.api.service.MediaService;
 import io.gravitee.rest.api.service.exceptions.UploadUnauthorized;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 import org.apache.commons.io.IOUtils;
 import org.glassfish.jersey.media.multipart.FormDataBodyPart;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
@@ -49,6 +46,10 @@ public class ApiMediaResource extends AbstractResource {
     @Inject
     private MediaService mediaService;
 
+    @PathParam("api")
+    @ApiParam(name = "api", required = true, value = "The ID of the API")
+    private String api;
+
     @POST
     @ApiOperation(value = "Create a media for an API",
             notes = "User must have the API_DOCUMENTATION[CREATE] permission to use this service")
@@ -61,8 +62,7 @@ public class ApiMediaResource extends AbstractResource {
     @Path("/upload")
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     @Produces("text/plain")
-    public Response uploadImage(
-            @PathParam("api") String api,
+    public Response uploadApiMediaImage(
             @FormDataParam("file") InputStream uploadedInputStream,
             @FormDataParam("file") FormDataContentDisposition fileDetail,
             @FormDataParam("file") final FormDataBodyPart body
@@ -94,9 +94,8 @@ public class ApiMediaResource extends AbstractResource {
     @GET
     @Path("/{hash}")
     @ApiOperation(value = "Retrieve a media for an API")
-    public Response getImage(
+    public Response getApiMediaImage(
             @Context Request request,
-            @PathParam("api") String api,
             @PathParam("hash") String hash) {
         MediaEntity mediaEntity = mediaService.findByHashAndApiId(hash, api);
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResource.java
@@ -56,6 +56,11 @@ public class ApiMembersResource extends AbstractResource {
     @Inject
     private UserService userService;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
+
     @GET
     @Path("/permissions")
     @Produces(MediaType.APPLICATION_JSON)
@@ -64,7 +69,7 @@ public class ApiMembersResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "API member's permissions", response = MemberEntity.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Response getPermissions(@PathParam("api") String api) {
+    public Response getApiMembersPermissions() {
         final ApiEntity apiEntity = apiService.findById(api);
         Map<String, char[]> permissions = new HashMap<>();
         if (isAuthenticated()) {
@@ -91,7 +96,7 @@ public class ApiMembersResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_MEMBER, acls = RolePermissionAction.READ)
     })
-    public List<MembershipListItem> listApiMembers(@PathParam("api") String api) {
+    public List<MembershipListItem> getApiMembers() {
         apiService.findById(api);
         return membershipService.getMembersByReference(MembershipReferenceType.API, api)
                 .stream()
@@ -111,9 +116,7 @@ public class ApiMembersResource extends AbstractResource {
             @Permission(value = RolePermission.API_MEMBER, acls = RolePermissionAction.CREATE),
             @Permission(value = RolePermission.API_MEMBER, acls = RolePermissionAction.UPDATE)
     })
-    public Response addOrUpdateApiMember(
-            @PathParam("api") String api,
-            @Valid @NotNull ApiMembership apiMembership) {
+    public Response addOrUpdateApiMember(@Valid @NotNull ApiMembership apiMembership) {
 
         if (PRIMARY_OWNER.name().equals(apiMembership.getRole())) {
             throw new SinglePrimaryOwnerException(RoleScope.API);
@@ -152,8 +155,7 @@ public class ApiMembersResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_MEMBER, acls = RolePermissionAction.UPDATE)
     })
-    public Response transferOwnership(
-            @PathParam("api") String api,
+    public Response transferApiMemberOwnership(
             @Valid @NotNull TransferOwnership transferOwnership) {
         List<RoleEntity> newRoles = new ArrayList<>();
 
@@ -181,7 +183,6 @@ public class ApiMembersResource extends AbstractResource {
             @Permission(value = RolePermission.API_MEMBER, acls = RolePermissionAction.DELETE)
     })
     public Response deleteApiMember(
-            @PathParam("api") String api,
             @ApiParam(name = "user", required = true) @NotNull @QueryParam("user") String userId) {
         apiService.findById(api);
         try {

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMetadataResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMetadataResource.java
@@ -16,16 +16,15 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
-import io.gravitee.rest.api.model.*;
-import io.gravitee.rest.api.model.permissions.RolePermission;
-import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
+import io.gravitee.rest.api.model.ApiMetadataEntity;
+import io.gravitee.rest.api.model.NewApiMetadataEntity;
+import io.gravitee.rest.api.model.UpdateApiMetadataEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.ApiMetadataService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -46,6 +45,11 @@ public class ApiMetadataResource extends AbstractResource {
     @Inject
     private ApiMetadataService metadataService;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List metadata for the given API",
@@ -56,8 +60,7 @@ public class ApiMetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_METADATA, acls = RolePermissionAction.READ)
     })
-    public List<ApiMetadataEntity> listApiMetadatas(
-            @PathParam("api") String api) {
+    public List<ApiMetadataEntity> getApiMetadatas() {
         return metadataService.findAllByApi(api);
     }
 
@@ -73,7 +76,7 @@ public class ApiMetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_METADATA, acls = RolePermissionAction.READ)
     })
-    public ApiMetadataEntity getApiMetadata(@PathParam("api") String api, @PathParam("metadata") String metadata) {
+    public ApiMetadataEntity getApiMetadata(@PathParam("metadata") String metadata) {
         return metadataService.findByIdAndApi(metadata, api);
     }
 
@@ -88,7 +91,7 @@ public class ApiMetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_METADATA, acls = RolePermissionAction.CREATE)
     })
-    public Response create(@PathParam("api") String api, @Valid @NotNull final NewApiMetadataEntity metadata) {
+    public Response createApiMetadata(@Valid @NotNull final NewApiMetadataEntity metadata) {
         // prevent creation of a metadata on an another API
         metadata.setApiId(api);
 
@@ -111,9 +114,8 @@ public class ApiMetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_METADATA, acls = RolePermissionAction.UPDATE)
     })
-    public Response update(@PathParam("api") String api,
-                           @PathParam("metadata") String metadataPathParam,
-                           @Valid @NotNull final UpdateApiMetadataEntity metadata) {
+    public Response updateApiMetadata(@PathParam("metadata") String metadataPathParam,
+                                      @Valid @NotNull final UpdateApiMetadataEntity metadata) {
         // prevent update of a metadata on an another API
         metadata.setApiId(api);
 
@@ -130,7 +132,7 @@ public class ApiMetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_METADATA, acls = RolePermissionAction.DELETE)
     })
-    public Response delete(@PathParam("api") String api, @PathParam("metadata") String metadata) {
+    public Response deleteApiMetadata(@PathParam("metadata") String metadata) {
         metadataService.delete(metadata, api);
         return Response.noContent().build();
     }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiNotificationSettingsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiNotificationSettingsResource.java
@@ -27,8 +27,9 @@ import io.gravitee.rest.api.service.PortalNotificationConfigService;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import org.springframework.beans.factory.annotation.Autowired;
+import io.swagger.annotations.ApiParam;
 
+import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
@@ -45,11 +46,16 @@ import static io.gravitee.rest.api.model.permissions.RolePermissionAction.*;
 @Api(tags = {"API Notifications"})
 public class ApiNotificationSettingsResource extends AbstractResource {
 
-    @Autowired
+    @Inject
     private PortalNotificationConfigService portalNotificationConfigService;
 
-    @Autowired
+    @Inject
     private GenericNotificationConfigService genericNotificationConfigService;
+
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
 
     @GET
     @ApiOperation(value = "Get notification settings")
@@ -57,7 +63,7 @@ public class ApiNotificationSettingsResource extends AbstractResource {
     @Permissions({
             @Permission(value = API_NOTIFICATION, acls = READ)
     })
-    public List<Object> get(@PathParam("api") String api) {
+    public List<Object> getApiNotificationSettings() {
         List<Object> settings = new ArrayList<>();
         settings.add(portalNotificationConfigService.findById(getAuthenticatedUser(), NotificationReferenceType.API, api));
         if (hasPermission(API_NOTIFICATION, api, CREATE, UPDATE, DELETE)){
@@ -70,7 +76,7 @@ public class ApiNotificationSettingsResource extends AbstractResource {
     @ApiOperation(value = "Create notification settings")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    public Object create(@PathParam("api") String api, GenericNotificationConfigEntity config) {
+    public Object createApiNotificationSettings(GenericNotificationConfigEntity config) {
         if (!api.equals(config.getReferenceId())
                 || !NotificationReferenceType.API.name().equals(config.getReferenceType())) {
             throw new ForbiddenAccessException();
@@ -93,8 +99,7 @@ public class ApiNotificationSettingsResource extends AbstractResource {
     @Permissions({
             @Permission(value = API_NOTIFICATION, acls = UPDATE)
     })
-    public GenericNotificationConfigEntity update(
-            @PathParam("api") String api,
+    public GenericNotificationConfigEntity updateApiGeneralNotificationSettings(
             @PathParam("notificationId") String notificationId,
             GenericNotificationConfigEntity config) {
         if (!api.equals(config.getReferenceId())
@@ -113,8 +118,7 @@ public class ApiNotificationSettingsResource extends AbstractResource {
     @Permissions({
             @Permission(value = API_NOTIFICATION, acls = READ)
     })
-    public PortalNotificationConfigEntity update(
-            @PathParam("api") String api,
+    public PortalNotificationConfigEntity updateApiPortalNotificationSettings(
             PortalNotificationConfigEntity config) {
         if (!api.equals(config.getReferenceId())
                 || !NotificationReferenceType.API.name().equals(config.getReferenceType())
@@ -133,8 +137,7 @@ public class ApiNotificationSettingsResource extends AbstractResource {
     @Permissions({
             @Permission(value = API_NOTIFICATION, acls = DELETE)
     })
-    public Response delete(
-            @PathParam("api") String api,
+    public Response deleteApiNotificationSettings(
             @PathParam("notificationId") String notificationId) {
         genericNotificationConfigService.delete(notificationId);
         return Response.noContent().build();

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPagesResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPagesResource.java
@@ -16,14 +16,14 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
+import io.gravitee.rest.api.management.rest.utils.HttpHeadersUtil;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.documentation.PageQuery;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.management.rest.security.Permission;
-import io.gravitee.rest.api.management.rest.security.Permissions;
-import io.gravitee.rest.api.management.rest.utils.HttpHeadersUtil;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.PageService;
@@ -63,6 +63,11 @@ public class ApiPagesResource extends AbstractResource {
     @Context
     private ResourceContext resourceContext;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List pages",
@@ -70,9 +75,8 @@ public class ApiPagesResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List of pages", response = PageEntity.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<PageEntity> listPages(
+    public List<PageEntity> getApiPages(
             @HeaderParam("Accept-Language") String acceptLang,
-            @PathParam("api") String api,
             @QueryParam("homepage") Boolean homepage,
             @QueryParam("type") PageType type,
             @QueryParam("parent") String parent,
@@ -113,8 +117,7 @@ public class ApiPagesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_DOCUMENTATION, acls = RolePermissionAction.CREATE)
     })
-    public Response createPage(
-            @PathParam("api") String api,
+    public Response createApiPage(
             @ApiParam(name = "page", required = true) @Valid @NotNull NewPageEntity newPageEntity) {
         if(newPageEntity.getType().equals(PageType.SYSTEM_FOLDER)) {
             throw new PageSystemFolderActionException("Create");
@@ -144,9 +147,7 @@ public class ApiPagesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_DOCUMENTATION, acls = RolePermissionAction.UPDATE)
     })
-    public Response fetchAllPages(
-            @PathParam("api") String api
-    ) {
+    public Response fetchAllApiPages() {
         String contributor = getAuthenticatedUser();
         pageService.fetchAll(new PageQuery.Builder().api(api).build(), contributor);
         return Response.noContent().build();
@@ -169,8 +170,7 @@ public class ApiPagesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_DOCUMENTATION, acls = RolePermissionAction.CREATE)
     })
-    public List<PageEntity> importFiles(
-            @PathParam("api") String api,
+    public List<PageEntity> importApiPageFiles(
             @ApiParam(name = "page", required = true) @Valid @NotNull ImportPageEntity pageEntity) {
         pageEntity.setLastContributor(getAuthenticatedUser());
         return pageService.importFiles(api, pageEntity);
@@ -188,8 +188,7 @@ public class ApiPagesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_DOCUMENTATION, acls = RolePermissionAction.CREATE)
     })
-    public List<PageEntity> updateImportFiles(
-            @PathParam("api") String api,
+    public List<PageEntity> updateApiPageImportFiles(
             @ApiParam(name = "page", required = true) @Valid @NotNull ImportPageEntity pageEntity) {
         pageEntity.setLastContributor(getAuthenticatedUser());
         return pageService.importFiles(api, pageEntity);

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPlansResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPlansResource.java
@@ -67,6 +67,11 @@ public class ApiPlansResource extends AbstractResource {
     @Context
     private ResourceContext resourceContext;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
@@ -75,8 +80,7 @@ public class ApiPlansResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List accessible plans for current user", response = PlanEntity.class, responseContainer = "Set"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<PlanEntity> listPlans(
-            @PathParam("api") final String api,
+    public List<PlanEntity> getApiPlans(
             @QueryParam("status") @DefaultValue("published") final PlanStatusParam wishedStatus,
             @QueryParam("security") final PlanSecurityParam security) {
         if (!hasPermission(RolePermission.API_PLAN, api, RolePermissionAction.READ) &&
@@ -107,8 +111,7 @@ public class ApiPlansResource extends AbstractResource {
     @Permissions({
             @Permission(value = API_PLAN, acls = CREATE)
     })
-    public Response createPlan(
-            @PathParam("api") String api,
+    public Response createApiPlan(
             @ApiParam(name = "plan", required = true) @Valid @NotNull NewPlanEntity newPlanEntity) {
         newPlanEntity.setApi(api);
         newPlanEntity.setType(PlanType.API);
@@ -134,8 +137,7 @@ public class ApiPlansResource extends AbstractResource {
     @Permissions({
             @Permission(value = API_PLAN, acls = UPDATE)
     })
-    public Response updatePlan(
-            @PathParam("api") String api,
+    public Response updateApiPlan(
             @PathParam("plan") String plan,
             @ApiParam(name = "plan", required = true) @Valid @NotNull UpdatePlanEntity updatePlanEntity) {
 
@@ -169,8 +171,7 @@ public class ApiPlansResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "Plan information", response = PlanEntity.class),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Response getPlan(
-            @PathParam("api") String api,
+    public Response getApiPlan(
             @PathParam("plan") String plan) {
 
         if (Visibility.PUBLIC.equals(apiService.findById(api).getVisibility())
@@ -199,8 +200,7 @@ public class ApiPlansResource extends AbstractResource {
     @Permissions({
             @Permission(value = API_PLAN, acls = DELETE)
     })
-    public Response deletePlan(
-            @PathParam("api") String api,
+    public Response deleteApiPlan(
             @PathParam("plan") String plan) {
         PlanEntity planEntity = planService.findById(plan);
         if (! planEntity.getApi().equals(api)) {
@@ -226,8 +226,7 @@ public class ApiPlansResource extends AbstractResource {
     @Permissions({
             @Permission(value = API_PLAN, acls = UPDATE)
     })
-    public Response closePlan(
-            @PathParam("api") String api,
+    public Response closeApiPlan(
             @PathParam("plan") String plan) {
         PlanEntity planEntity = planService.findById(plan);
         if (! planEntity.getApi().equals(api)) {
@@ -251,8 +250,7 @@ public class ApiPlansResource extends AbstractResource {
     @Permissions({
             @Permission(value = API_PLAN, acls = UPDATE)
     })
-    public Response publishPlan(
-            @PathParam("api") String api,
+    public Response publishApiPlan(
             @PathParam("plan") String plan) {
         PlanEntity planEntity = planService.findById(plan);
         if (! planEntity.getApi().equals(api)) {
@@ -276,8 +274,7 @@ public class ApiPlansResource extends AbstractResource {
     @Permissions({
             @Permission(value = API_PLAN, acls = UPDATE)
     })
-    public Response depreciatePlan(
-            @PathParam("api") String api,
+    public Response depreciateApiPlan(
             @PathParam("plan") String plan) {
         PlanEntity planEntity = planService.findById(plan);
         if (! planEntity.getApi().equals(api)) {

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiQualityRulesResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiQualityRulesResource.java
@@ -26,8 +26,9 @@ import io.gravitee.rest.api.model.quality.UpdateApiQualityRuleEntity;
 import io.gravitee.rest.api.service.ApiQualityRuleService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import org.springframework.beans.factory.annotation.Autowired;
+import io.swagger.annotations.ApiParam;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -43,8 +44,13 @@ import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
 @Api(tags = {"API Quality"})
 public class ApiQualityRulesResource extends AbstractResource {
 
-    @Autowired
+    @Inject
     private ApiQualityRuleService apiQualityRuleService;
+
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
 
     @GET
     @ApiOperation(value = "List quality rules for an API",
@@ -53,7 +59,7 @@ public class ApiQualityRulesResource extends AbstractResource {
     @Permissions({
             @Permission(value = API_QUALITY_RULE, acls = READ)
     })
-    public List<ApiQualityRuleEntity> list(@PathParam("api") String api) {
+    public List<ApiQualityRuleEntity> getApiQualityRules() {
         return apiQualityRuleService.findByApi(api);
     }
 
@@ -65,7 +71,7 @@ public class ApiQualityRulesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_QUALITY_RULE, acls = RolePermissionAction.CREATE)
     })
-    public ApiQualityRuleEntity create(@PathParam("api") String api, @Valid @NotNull final NewApiQualityRuleEntity apiQualityRuleEntity) {
+    public ApiQualityRuleEntity createApiQualityRule(@Valid @NotNull final NewApiQualityRuleEntity apiQualityRuleEntity) {
         apiQualityRuleEntity.setApi(api);
         return apiQualityRuleService.create(apiQualityRuleEntity);
     }
@@ -79,7 +85,7 @@ public class ApiQualityRulesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_QUALITY_RULE, acls = RolePermissionAction.UPDATE)
     })
-    public ApiQualityRuleEntity update(@PathParam("api") String api, @PathParam("qualityRule") String qualityRule, @Valid @NotNull final UpdateApiQualityRuleEntity apiQualityRuleEntity) {
+    public ApiQualityRuleEntity updateApiQualityRule(@PathParam("qualityRule") String qualityRule, @Valid @NotNull final UpdateApiQualityRuleEntity apiQualityRuleEntity) {
         apiQualityRuleEntity.setApi(api);
         apiQualityRuleEntity.setQualityRule(qualityRule);
         return apiQualityRuleService.update(apiQualityRuleEntity);

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiRatingResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiRatingResource.java
@@ -28,8 +28,9 @@ import io.gravitee.rest.api.service.RatingService;
 import io.gravitee.rest.api.service.exceptions.UnauthorizedAccessException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import org.springframework.beans.factory.annotation.Autowired;
+import io.swagger.annotations.ApiParam;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
@@ -46,13 +47,18 @@ import static java.util.stream.Collectors.toList;
 @Api(tags = {"API Ratings"})
 public class ApiRatingResource extends AbstractResource {
 
-    @Autowired
+    @Inject
     private RatingService ratingService;
+
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
 
     @GET
     @ApiOperation(value = "List ratings for an API")
     @Produces(MediaType.APPLICATION_JSON)
-    public Page<RatingEntity> list(@PathParam("api") String api, @Min(1) @QueryParam("pageNumber") int pageNumber, @QueryParam("pageSize") int pageSize) {
+    public Page<RatingEntity> getApiRating(@Min(1) @QueryParam("pageNumber") int pageNumber, @QueryParam("pageSize") int pageSize) {
         final ApiEntity apiEntity = apiService.findById(api);
         if (PUBLIC.equals(apiEntity.getVisibility()) || hasPermission(RolePermission.API_RATING, api, RolePermissionAction.READ)) {
             final Page<RatingEntity> ratingEntityPage =
@@ -69,7 +75,7 @@ public class ApiRatingResource extends AbstractResource {
     @GET
     @ApiOperation(value = "Retrieve current rating for an API provided by the authenticated user")
     @Produces(MediaType.APPLICATION_JSON)
-    public RatingEntity getByApiAndUser(@PathParam("api") String api) {
+    public RatingEntity getApiRatingByApiAndUser() {
         if (!isAuthenticated()) {
             return null;
         }
@@ -85,7 +91,7 @@ public class ApiRatingResource extends AbstractResource {
     @ApiOperation(value = "Get the rating summary for an API")
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public RatingSummaryEntity getSummaryByApi(@PathParam("api") String api) {
+    public RatingSummaryEntity getApiRatingSummaryByApi() {
         final ApiEntity apiEntity = apiService.findById(api);
         if (PUBLIC.equals(apiEntity.getVisibility()) || hasPermission(RolePermission.API_RATING, api, RolePermissionAction.READ)) {
             return ratingService.findSummaryByApi(api);
@@ -102,7 +108,7 @@ public class ApiRatingResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_RATING, acls = RolePermissionAction.CREATE)
     })
-    public RatingEntity create(@PathParam("api") String api, @Valid @NotNull final NewRatingEntity rating) {
+    public RatingEntity createApiRating(@Valid @NotNull final NewRatingEntity rating) {
         rating.setApi(api);
         return filterPermission(api, ratingService.create(rating));
     }
@@ -116,7 +122,7 @@ public class ApiRatingResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_RATING, acls = RolePermissionAction.UPDATE)
     })
-    public RatingEntity update(@PathParam("api") String api, @PathParam("rating") String rating, @Valid @NotNull final UpdateRatingEntity ratingEntity) {
+    public RatingEntity updateApiRating(@PathParam("rating") String rating, @Valid @NotNull final UpdateRatingEntity ratingEntity) {
         ratingEntity.setId(rating);
         ratingEntity.setApi(api);
         return filterPermission(api, ratingService.update(ratingEntity));
@@ -130,7 +136,7 @@ public class ApiRatingResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_RATING, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("rating") String rating) {
+    public void deleteApiRating(@PathParam("rating") String rating) {
         ratingService.delete(rating);
     }
 
@@ -143,7 +149,7 @@ public class ApiRatingResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_RATING_ANSWER, acls = RolePermissionAction.CREATE)
     })
-    public RatingEntity createAnswer(@PathParam("api") String api, @PathParam("rating") String rating, @Valid @NotNull final NewRatingAnswerEntity answer) {
+    public RatingEntity createApiRatingAnswer(@PathParam("rating") String rating, @Valid @NotNull final NewRatingAnswerEntity answer) {
         answer.setRatingId(rating);
         return filterPermission(api, ratingService.createAnswer(answer));
     }
@@ -156,7 +162,7 @@ public class ApiRatingResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_RATING_ANSWER, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("rating") String rating, @PathParam("answer") String answer) {
+    public void deleteApiRatingAnswer(@PathParam("rating") String rating, @PathParam("answer") String answer) {
         ratingService.deleteAnswer(rating, answer);
     }
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscribersResource.java
@@ -24,10 +24,7 @@ import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.SubscriptionService;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -54,6 +51,11 @@ public class ApiSubscribersResource extends AbstractResource {
     @Context
     private ResourceContext resourceContext;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List subscribers for the API",
@@ -61,8 +63,7 @@ public class ApiSubscribersResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "Paged result of API subscribers", response = ApplicationEntity.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Collection<ApplicationEntity> listApiSubscribers(
-            @PathParam("api") String api) {
+    public Collection<ApplicationEntity> getApiSubscribers() {
         if (!hasPermission(RolePermission.API_SUBSCRIPTION, api, RolePermissionAction.READ) &&
                 !hasPermission(RolePermission.API_LOG, api, RolePermissionAction.READ)) {
             throw new ForbiddenAccessException();

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiSubscriptionResource.java
@@ -32,7 +32,6 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
 import java.net.URI;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static io.gravitee.rest.api.model.SubscriptionStatus.*;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
@@ -59,6 +58,11 @@ public class ApiSubscriptionResource extends AbstractResource {
     @Inject
     private UserService userService;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("api")
+    @ApiParam(name = "api", hidden = true)
+    private String api;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Get a subscription",
@@ -71,7 +75,6 @@ public class ApiSubscriptionResource extends AbstractResource {
             @Permission(value = RolePermission.API_SUBSCRIPTION, acls = RolePermissionAction.READ)
     })
     public Subscription getApiSubscription(
-            @PathParam("api") String api,
             @PathParam("subscription") String subscription) {
         return convert(subscriptionService.findById(subscription));
     }
@@ -89,7 +92,6 @@ public class ApiSubscriptionResource extends AbstractResource {
             @Permission(value = RolePermission.API_SUBSCRIPTION, acls = UPDATE)
     })
     public Response processApiSubscription(
-            @PathParam("api") String api,
             @PathParam("subscription") String subscription,
             @ApiParam(name = "subscription", required = true) @Valid @NotNull ProcessSubscriptionEntity processSubscriptionEntity) {
 
@@ -120,7 +122,6 @@ public class ApiSubscriptionResource extends AbstractResource {
             @Permission(value = RolePermission.API_SUBSCRIPTION, acls = UPDATE)
     })
     public Response updateApiSubscription(
-            @PathParam("api") String api,
             @PathParam("subscription") String subscription,
             @ApiParam(name = "subscription", required = true) @Valid @NotNull UpdateSubscriptionEntity updateSubscriptionEntity) {
 
@@ -151,8 +152,7 @@ public class ApiSubscriptionResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_SUBSCRIPTION, acls = RolePermissionAction.UPDATE)
     })
-    public Response changeSubscriptionStatus(
-            @PathParam("api") String api,
+    public Response changeApiSubscriptionStatus(
             @PathParam("subscription") String subscription,
             @ApiParam(required = true, allowableValues = "CLOSED, PAUSED, RESUMED")
             @QueryParam("status") SubscriptionStatus subscriptionStatus) {
@@ -182,8 +182,7 @@ public class ApiSubscriptionResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_SUBSCRIPTION, acls = RolePermissionAction.READ)
     })
-    public List<ApiKeyEntity> listApiKeysForSubscription(
-            @PathParam("api") String api,
+    public List<ApiKeyEntity> getApiKeysForSubscription(
             @PathParam("subscription") String subscription) {
         return apiKeyService.findBySubscription(subscription);
     }
@@ -199,7 +198,6 @@ public class ApiSubscriptionResource extends AbstractResource {
             @Permission(value = RolePermission.API_SUBSCRIPTION, acls = RolePermissionAction.UPDATE)
     })
     public Response renewApiKey(
-            @PathParam("api") String api,
             @PathParam("subscription") String subscription) {
         ApiKeyEntity apiKeyEntity = apiKeyService.renew(subscription);
         return Response
@@ -221,12 +219,11 @@ public class ApiSubscriptionResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.API_SUBSCRIPTION, acls = RolePermissionAction.DELETE)
     })
-    public Response revokeApiKey(
-            @PathParam("api") String api,
+    public Response revokeSubscriptionApiKey(
             @PathParam("subscription") String subscription,
             @PathParam("key") String apiKey) {
         ApiKeyEntity apiKeyEntity = apiKeyService.findByKey(apiKey);
-        if (apiKeyEntity.getSubscription() != null && ! subscription.equals(apiKeyEntity.getSubscription())) {
+        if (apiKeyEntity.getSubscription() != null && !subscription.equals(apiKeyEntity.getSubscription())) {
             return Response
                     .status(Response.Status.BAD_REQUEST)
                     .entity("'key' parameter does not correspond to the subscription")
@@ -253,7 +250,6 @@ public class ApiSubscriptionResource extends AbstractResource {
             @Permission(value = RolePermission.API_SUBSCRIPTION, acls = RolePermissionAction.DELETE)
     })
     public Response reactivateApiKey(
-            @PathParam("api") String api,
             @PathParam("subscription") String subscription,
             @PathParam("key") String apiKey) {
         ApiKeyEntity apiKeyEntity = apiKeyService.findByKey(apiKey);
@@ -284,7 +280,6 @@ public class ApiSubscriptionResource extends AbstractResource {
             @Permission(value = RolePermission.API_SUBSCRIPTION, acls = UPDATE)
     })
     public Response transferApiSubscription(
-            @PathParam("api") String api,
             @PathParam("subscription") String subscription,
             @ApiParam(name = "subscription", required = true) @Valid @NotNull TransferSubscriptionEntity transferSubscriptionEntity) {
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.rest.resource;
 import io.gravitee.common.component.Lifecycle;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.definition.model.VirtualHost;
+import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.management.rest.resource.param.ApisParam;
 import io.gravitee.rest.api.management.rest.resource.param.VerifyApiParam;
 import io.gravitee.rest.api.management.rest.security.Permission;
@@ -33,7 +34,6 @@ import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiAlreadyExistsException;
 import io.gravitee.rest.api.service.notification.ApiHook;
 import io.gravitee.rest.api.service.notification.Hook;
-import io.gravitee.repository.exceptions.TechnicalException;
 import io.swagger.annotations.*;
 
 import javax.inject.Inject;
@@ -88,7 +88,7 @@ public class ApisResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List accessible APIs for current user", response = ApiListItem.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<ApiListItem> listApis(@BeanParam final ApisParam apisParam) {
+    public List<ApiListItem> getApis(@BeanParam final ApisParam apisParam) {
 
         final ApiQuery apiQuery = new ApiQuery();
         if (apisParam.getGroup() != null) {
@@ -178,7 +178,7 @@ public class ApisResource extends AbstractResource {
             @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.CREATE),
             @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.UPDATE)
     })
-    public Response importDefinition(
+    public Response importApiDefinition(
             @ApiParam(name = "definition", required = true) @Valid @NotNull String apiDefinition) {
 
         return Response.ok(apiService.createWithImportedDefinition(null, apiDefinition, getAuthenticatedUser())).build();
@@ -194,7 +194,7 @@ public class ApisResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.CREATE)
     })
-    public Response importSwagger(
+    public Response importSwaggerApi(
             @ApiParam(name = "swagger", required = true) @Valid @NotNull ImportSwaggerDescriptorEntity swaggerDescriptor) {
         final ApiEntity api = apiService.create(swaggerService.createAPI(swaggerDescriptor), getAuthenticatedUser(), swaggerDescriptor);
         return Response
@@ -213,7 +213,7 @@ public class ApisResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.CREATE)
     })
-    public Response verify(@Valid VerifyApiParam verifyApiParam) {
+    public Response verifyApi(@Valid VerifyApiParam verifyApiParam) {
         // TODO : create verify service to query repository with criteria
         virtualHostService.validate(Collections.singletonList(new VirtualHost(verifyApiParam.getContextPath())));
         return Response.ok().entity("API context [" + verifyApiParam.getContextPath() + "] is available").build();
@@ -221,9 +221,9 @@ public class ApisResource extends AbstractResource {
 
     @GET
     @Path("/hooks")
-    @ApiOperation("Get the list of available hooks")
+    @ApiOperation(value = "Get the list of available hooks")
     @Produces(MediaType.APPLICATION_JSON)
-    public Hook[] getHooks() {
+    public Hook[] getApiHooks() {
         return Arrays.stream(ApiHook.values()).filter(h -> !h.isHidden()).toArray(Hook[]::new);
     }
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationAlertsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationAlertsResource.java
@@ -25,12 +25,9 @@ import io.gravitee.rest.api.model.alert.UpdateAlertTriggerEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.AlertService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
+import io.swagger.annotations.*;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -47,8 +44,13 @@ import static io.gravitee.rest.api.model.permissions.RolePermissionAction.READ;
 @Api(tags = {"Application Alerts"})
 public class ApplicationAlertsResource extends AbstractResource {
 
-    @Autowired
+    @Inject
     private AlertService alertService;
+
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("application")
+    @ApiParam(name = "application", hidden = true)
+    private String application;
 
     @GET
     @ApiOperation(value = "List configured alerts of an application",
@@ -60,7 +62,7 @@ public class ApplicationAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = APPLICATION_ALERT, acls = READ)
     })
-    public List<AlertTriggerEntity> list(@PathParam("application") String application) {
+    public List<AlertTriggerEntity> getApplicationAlerts() {
         return alertService.findByReference(APPLICATION, application);
     }
 
@@ -75,7 +77,7 @@ public class ApplicationAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ALERT, acls = READ)
     })
-    public AlertStatusEntity status(@PathParam("application") String application) {
+    public AlertStatusEntity getApplicationAlertsStatus() {
         return alertService.getStatus();
     }
 
@@ -90,7 +92,7 @@ public class ApplicationAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_ALERT, acls = RolePermissionAction.CREATE)
     })
-    public AlertTriggerEntity create(@PathParam("application") String application, @Valid @NotNull final NewAlertTriggerEntity alertEntity) {
+    public AlertTriggerEntity createApplicationAlert(@Valid @NotNull final NewAlertTriggerEntity alertEntity) {
         alertEntity.setReferenceType(APPLICATION);
         alertEntity.setReferenceId(application);
         return alertService.create(alertEntity);
@@ -108,7 +110,7 @@ public class ApplicationAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_ALERT, acls = RolePermissionAction.UPDATE)
     })
-    public AlertTriggerEntity update(@PathParam("application") String application, @PathParam("alert") String alert, @Valid @NotNull final UpdateAlertTriggerEntity alertEntity) {
+    public AlertTriggerEntity updateApplicationAlert(@PathParam("alert") String alert, @Valid @NotNull final UpdateAlertTriggerEntity alertEntity) {
         alertEntity.setId(alert);
         alertEntity.setReferenceType(APPLICATION);
         alertEntity.setReferenceId(application);
@@ -126,7 +128,7 @@ public class ApplicationAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_ALERT, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("application") String application, @PathParam("alert") String alert) {
+    public void deleteApplicationAlert(@PathParam("alert") String alert) {
         alertService.delete(alert, application);
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationAnalyticsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationAnalyticsResource.java
@@ -26,10 +26,7 @@ import io.gravitee.rest.api.model.analytics.query.*;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.AnalyticsService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.BeanParam;
@@ -53,6 +50,11 @@ public class ApplicationAnalyticsResource extends AbstractResource {
     @Inject
     private AnalyticsService analyticsService;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("application")
+    @ApiParam(name = "application", hidden = true)
+    private String application;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Get application analytics",
@@ -63,14 +65,13 @@ public class ApplicationAnalyticsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_ANALYTICS, acls = RolePermissionAction.READ)
     })
-    public Response hits(
-            @PathParam("application") String application,
+    public Response getApplicationAnalyticsHits(
             @BeanParam AnalyticsParam analyticsParam) {
         analyticsParam.validate();
 
         Analytics analytics = null;
 
-        switch(analyticsParam.getTypeParam().getValue()) {
+        switch (analyticsParam.getTypeParam().getValue()) {
             case DATE_HISTO:
                 analytics = executeDateHisto(application, analyticsParam);
                 break;

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationLogsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationLogsResource.java
@@ -16,19 +16,16 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.resource.param.LogsParam;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.analytics.query.LogQuery;
 import io.gravitee.rest.api.model.log.ApplicationRequest;
 import io.gravitee.rest.api.model.log.SearchLogResponse;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.management.rest.resource.param.LogsParam;
-import io.gravitee.rest.api.management.rest.security.Permission;
-import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.service.LogsService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.*;
@@ -48,6 +45,11 @@ public class ApplicationLogsResource extends AbstractResource {
     @Inject
     private LogsService logsService;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("application")
+    @ApiParam(name = "application", hidden = true)
+    private String application;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Get application logs")
@@ -57,9 +59,7 @@ public class ApplicationLogsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_LOG, acls = RolePermissionAction.READ)
     })
-    public SearchLogResponse applicationLogs(
-            @PathParam("application") String application,
-            @BeanParam LogsParam param) {
+    public SearchLogResponse getApplicationLogs(@BeanParam LogsParam param) {
 
         param.validate();
 
@@ -85,8 +85,7 @@ public class ApplicationLogsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_LOG, acls = RolePermissionAction.READ)
     })
-    public ApplicationRequest applicationLog(
-            @PathParam("application") String application,
+    public ApplicationRequest getApplicationLog(
             @PathParam("log") String logId,
             @QueryParam("timestamp") Long timestamp) {
         return logsService.findApplicationLog(logId, timestamp);
@@ -101,9 +100,8 @@ public class ApplicationLogsResource extends AbstractResource {
             @ApiResponse(code = 500, message = "Internal server error")})
     @Permissions({@Permission(value = RolePermission.APPLICATION_LOG, acls = RolePermissionAction.READ)})
     public Response exportApplicationLogsAsCSV(
-            @PathParam("application") String application,
             @BeanParam LogsParam param) {
-        final SearchLogResponse searchLogResponse = applicationLogs(application, param);
+        final SearchLogResponse searchLogResponse = getApplicationLogs(param);
         return Response
                 .ok(logsService.exportAsCsv(searchLogResponse))
                 .header(HttpHeaders.CONTENT_DISPOSITION, format("attachment;filename=logs-%s-%s.csv", application, System.currentTimeMillis()))

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationMetadataResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationMetadataResource.java
@@ -24,10 +24,7 @@ import io.gravitee.rest.api.model.UpdateApplicationMetadataEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.ApplicationMetadataService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -47,6 +44,11 @@ public class ApplicationMetadataResource extends AbstractResource {
     @Inject
     private ApplicationMetadataService metadataService;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("application")
+    @ApiParam(name = "application", hidden = true)
+    private String application;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List metadata for an application",
@@ -57,8 +59,7 @@ public class ApplicationMetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_METADATA, acls = RolePermissionAction.READ)
     })
-    public List<ApplicationMetadataEntity> listApplicationMetadatas(
-            @PathParam("application") String application) {
+    public List<ApplicationMetadataEntity> getApplicationMetadatas() {
         return metadataService.findAllByApplication(application);
     }
 
@@ -74,7 +75,7 @@ public class ApplicationMetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_METADATA, acls = RolePermissionAction.READ)
     })
-    public ApplicationMetadataEntity getApplicationMetadata(@PathParam("application") String application, @PathParam("metadata") String metadata) {
+    public ApplicationMetadataEntity getApplicationMetadata(@PathParam("metadata") String metadata) {
         return metadataService.findByIdAndApplication(metadata, application);
     }
 
@@ -89,7 +90,7 @@ public class ApplicationMetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_METADATA, acls = RolePermissionAction.CREATE)
     })
-    public Response create(@PathParam("application") String application, @Valid @NotNull final NewApplicationMetadataEntity metadata) {
+    public Response createApplicationMetadata(@Valid @NotNull final NewApplicationMetadataEntity metadata) {
         // prevent creation of a metadata on an another APPLICATION
         metadata.setApplicationId(application);
 
@@ -112,8 +113,7 @@ public class ApplicationMetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_METADATA, acls = RolePermissionAction.UPDATE)
     })
-    public Response update(@PathParam("application") String application,
-                           @PathParam("metadata") String metadataPathParam,
+    public Response updateApplicationMetadata(@PathParam("metadata") String metadataPathParam,
                            @Valid @NotNull final UpdateApplicationMetadataEntity metadata) {
         // prevent update of a metadata on an another APPLICATION
         metadata.setApplicationId(application);
@@ -131,7 +131,7 @@ public class ApplicationMetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_METADATA, acls = RolePermissionAction.DELETE)
     })
-    public Response delete(@PathParam("application") String application, @PathParam("metadata") String metadata) {
+    public Response deleteApplicationMetadata(@PathParam("metadata") String metadata) {
         metadataService.delete(metadata, application);
         return Response.noContent().build();
     }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationNotificationSettingsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationNotificationSettingsResource.java
@@ -27,8 +27,9 @@ import io.gravitee.rest.api.service.PortalNotificationConfigService;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import org.springframework.beans.factory.annotation.Autowired;
+import io.swagger.annotations.ApiParam;
 
+import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
@@ -45,11 +46,16 @@ import static io.gravitee.rest.api.model.permissions.RolePermissionAction.*;
 @Api(tags = {"Application Notifications"})
 public class ApplicationNotificationSettingsResource extends AbstractResource {
 
-    @Autowired
+    @Inject
     private PortalNotificationConfigService portalNotificationConfigService;
 
-    @Autowired
+    @Inject
     private GenericNotificationConfigService genericNotificationConfigService;
+
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("application")
+    @ApiParam(name = "application", hidden = true)
+    private String application;
 
     @GET
     @ApiOperation(value = "Get notification settings")
@@ -57,7 +63,7 @@ public class ApplicationNotificationSettingsResource extends AbstractResource {
     @Permissions({
             @Permission(value = APPLICATION_NOTIFICATION, acls = READ)
     })
-    public List<Object> get(@PathParam("application") String application) {
+    public List<Object> getApplicationNotificationSettings() {
         List<Object> settings = new ArrayList<>();
         settings.add(portalNotificationConfigService.findById(getAuthenticatedUser(), NotificationReferenceType.APPLICATION, application));
         if (hasPermission(APPLICATION_NOTIFICATION, application, CREATE, UPDATE, DELETE)){
@@ -70,7 +76,7 @@ public class ApplicationNotificationSettingsResource extends AbstractResource {
     @ApiOperation(value = "Create notification settings")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    public Object create(@PathParam("application") String application, GenericNotificationConfigEntity config) {
+    public Object createApplicationNotificationSettings(GenericNotificationConfigEntity config) {
         if (!application.equals(config.getReferenceId())
                 || !NotificationReferenceType.APPLICATION.name().equals(config.getReferenceType())) {
             throw new ForbiddenAccessException();
@@ -93,8 +99,7 @@ public class ApplicationNotificationSettingsResource extends AbstractResource {
     @Permissions({
             @Permission(value = APPLICATION_NOTIFICATION, acls = UPDATE)
     })
-    public GenericNotificationConfigEntity update(
-            @PathParam("application") String application,
+    public GenericNotificationConfigEntity updateApplicationGeneralNotificationSettings(
             @PathParam("notificationId") String notificationId,
             GenericNotificationConfigEntity config) {
         if (!application.equals(config.getReferenceId())
@@ -113,8 +118,7 @@ public class ApplicationNotificationSettingsResource extends AbstractResource {
     @Permissions({
             @Permission(value = APPLICATION_NOTIFICATION, acls = READ)
     })
-    public PortalNotificationConfigEntity update(
-            @PathParam("application") String application,
+    public PortalNotificationConfigEntity updateApplicationPortalNotificationSettings(
             PortalNotificationConfigEntity config) {
         if (!application.equals(config.getReferenceId())
                 || !NotificationReferenceType.APPLICATION.name().equals(config.getReferenceType())
@@ -133,8 +137,7 @@ public class ApplicationNotificationSettingsResource extends AbstractResource {
     @Permissions({
             @Permission(value = APPLICATION_NOTIFICATION, acls = DELETE)
     })
-    public Response delete(
-            @PathParam("application") String application,
+    public Response deleteApplicationNotificationSettings(
             @PathParam("notificationId") String notificationId) {
         genericNotificationConfigService.delete(notificationId);
         return Response.noContent().build();

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationResource.java
@@ -18,6 +18,8 @@ package io.gravitee.rest.api.management.rest.resource;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.repository.management.model.ApplicationType;
 import io.gravitee.repository.management.model.NotificationReferenceType;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.gravitee.rest.api.model.application.SimpleApplicationSettings;
@@ -25,16 +27,11 @@ import io.gravitee.rest.api.model.configuration.application.ApplicationTypeEntit
 import io.gravitee.rest.api.model.notification.NotifierEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.management.rest.security.Permission;
-import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.NotifierService;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.exceptions.ApplicationNotFoundException;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -42,7 +39,6 @@ import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.*;
-
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.util.List;
@@ -67,6 +63,10 @@ public class ApplicationResource extends AbstractResource {
     @Inject
     private ApplicationTypeService applicationTypeService;
 
+    @PathParam("application")
+    @ApiParam(name = "application", required = true)
+    private String application;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Get an application",
@@ -77,7 +77,7 @@ public class ApplicationResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ)
     })
-    public ApplicationEntity getApplication(@PathParam("application") String application) {
+    public ApplicationEntity getApplication() {
         return applicationService.findById(application);
     }
 
@@ -93,7 +93,7 @@ public class ApplicationResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ)
     })
-    public Response getApplicationType(@PathParam("application") String application) {
+    public Response getApplicationType() {
         ApplicationEntity applicationEntity = applicationService.findById(application);
         ApplicationTypeEntity applicationType = applicationTypeService.getApplicationType(applicationEntity.getType());
         return Response
@@ -113,7 +113,6 @@ public class ApplicationResource extends AbstractResource {
             @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.UPDATE)
     })
     public ApplicationEntity updateApplication(
-            @PathParam("application") String application,
             @Valid @NotNull(message = "An application must be provided") final UpdateApplicationEntity updatedApplication) {
         // To preserve backward compatibility, ensure that we have at least default settings for simple application type
         if (updatedApplication.getSettings() == null ||
@@ -138,7 +137,7 @@ public class ApplicationResource extends AbstractResource {
     @Permissions({
         @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.READ)
     })
-    public Response picture(@Context Request request, @PathParam("application") String application) throws ApplicationNotFoundException {
+    public Response getApplicationPicture(@Context Request request) throws ApplicationNotFoundException {
         PictureEntity picture = applicationService.getPicture(application);
 
         if (picture instanceof UrlPictureEntity) {
@@ -188,8 +187,7 @@ public class ApplicationResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.UPDATE)
     })
-    public ApplicationEntity renewClientSecret(
-            @PathParam("application") String application) {
+    public ApplicationEntity renewApplicationClientSecret() {
         return applicationService.renewClientSecret(application);
     }
 
@@ -202,7 +200,7 @@ public class ApplicationResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_DEFINITION, acls = RolePermissionAction.DELETE)
     })
-    public Response deleteApplication(@PathParam("application") String application) {
+    public Response deleteApplication() {
         applicationService.archive(application);
         return Response.noContent().build();
     }
@@ -218,7 +216,7 @@ public class ApplicationResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_NOTIFICATION, acls = RolePermissionAction.READ)
     })
-    public List<NotifierEntity> getNotifiers(@PathParam("application") String application) {
+    public List<NotifierEntity> getApplicationNotifiers() {
         return notifierService.list(NotificationReferenceType.APPLICATION, application);
     }
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscribedResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationSubscribedResource.java
@@ -25,10 +25,7 @@ import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.SubscriptionService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.GET;
@@ -55,6 +52,11 @@ public class ApplicationSubscribedResource extends AbstractResource {
     @Context
     private ResourceContext resourceContext;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("application")
+    @ApiParam(name = "application", hidden = true)
+    private String application;
+
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List APIs subscribed by the application",
@@ -65,8 +67,7 @@ public class ApplicationSubscribedResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.APPLICATION_SUBSCRIPTION, acls = RolePermissionAction.READ)
     })
-    public Collection<SubscribedApi> listApiSubscribed(
-            @PathParam("application") String application) {
+    public Collection<SubscribedApi> getApiSubscribed() {
         SubscriptionQuery subscriptionQuery = new SubscriptionQuery();
         subscriptionQuery.setApplication(application);
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApplicationsResource.java
@@ -16,6 +16,8 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.NewApplicationEntity;
 import io.gravitee.rest.api.model.application.ApplicationListItem;
@@ -23,8 +25,6 @@ import io.gravitee.rest.api.model.application.ApplicationSettings;
 import io.gravitee.rest.api.model.application.SimpleApplicationSettings;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.management.rest.security.Permission;
-import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.notification.ApplicationHook;
@@ -40,7 +40,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
-
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
@@ -74,7 +73,7 @@ public class ApplicationsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_APPLICATION, acls = RolePermissionAction.READ)
     })
-    public List<ApplicationListItem> listApplications(
+    public List<ApplicationListItem> getApplications(
             @QueryParam("group") final String group,
             @QueryParam("query") final String query) {
         Set<ApplicationListItem> applications;
@@ -164,7 +163,7 @@ public class ApplicationsResource extends AbstractResource {
             @ApiResponse(code = 200, message = "List of hooks"),
             @ApiResponse(code = 500, message = "Internal server error")})
     @Produces(MediaType.APPLICATION_JSON)
-    public Hook[] getHooks() {
+    public Hook[] getApplicationHooks() {
         return ApplicationHook.values();
     }
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AuditResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/AuditResource.java
@@ -30,8 +30,8 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.reflections.Reflections;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.ws.rs.*;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.Context;
@@ -50,7 +50,7 @@ public class AuditResource extends AbstractResource  {
     @Context
     private ResourceContext resourceContext;
 
-    @Autowired
+    @Inject
     private AuditService auditService;
 
     @GET
@@ -64,7 +64,7 @@ public class AuditResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_AUDIT, acls = RolePermissionAction.READ)
     })
-    public MetadataPage<AuditEntity> list(@BeanParam AuditParam param){
+    public MetadataPage<AuditEntity> getAudits(@BeanParam AuditParam param){
 
         AuditQuery query = new AuditQuery();
         query.setFrom(param.getFrom());
@@ -100,7 +100,7 @@ public class AuditResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_AUDIT, acls = RolePermissionAction.READ)
     })
-    public Response getEvents() {
+    public Response getAuditEvents() {
         if (events.isEmpty()) {
             Set<Class<? extends Audit.AuditEvent>> subTypesOf =
                     new Reflections("io.gravitee.repository.management.model")

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoriesResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoriesResource.java
@@ -28,8 +28,8 @@ import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.CategoryService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -52,13 +52,13 @@ public class CategoriesResource extends AbstractCategoryResource  {
     @Context
     private ResourceContext resourceContext;
 
-    @Autowired
+    @Inject
     private CategoryService categoryService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Retrieve list of categories")
-    public List<CategoryEntity> list()  {
+    public List<CategoryEntity> getCategories()  {
         Set<ApiEntity> apis;
         if (isAdmin()) {
             apis = apiService.findAll();
@@ -92,7 +92,7 @@ public class CategoriesResource extends AbstractCategoryResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_CATEGORY, acls = RolePermissionAction.CREATE)
     })
-    public CategoryEntity create(@Valid @NotNull final NewCategoryEntity category) {
+    public CategoryEntity createCategory(@Valid @NotNull final NewCategoryEntity category) {
         return categoryService.create(category);
     }
 
@@ -105,11 +105,11 @@ public class CategoriesResource extends AbstractCategoryResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_CATEGORY, acls = RolePermissionAction.UPDATE)
     })
-    public List<CategoryEntity> update(@Valid @NotNull final List<UpdateCategoryEntity> categories) {
+    public List<CategoryEntity> updateCategories(@Valid @NotNull final List<UpdateCategoryEntity> categories) {
         return categoryService.update(categories);
     }
 
-    @Path("{id}")
+    @Path("{categoryId}")
     public CategoryResource getCategoryResource() {
         return resourceContext.getResource(CategoryResource.class);
     }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoryResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CategoryResource.java
@@ -17,24 +17,20 @@ package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.exception.InvalidImageException;
-import io.gravitee.rest.api.model.InlinePictureEntity;
-import io.gravitee.rest.api.model.UpdateCategoryEntity;
-import io.gravitee.rest.api.model.CategoryEntity;
-import io.gravitee.rest.api.model.permissions.RolePermission;
-import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
+import io.gravitee.rest.api.model.CategoryEntity;
+import io.gravitee.rest.api.model.InlinePictureEntity;
+import io.gravitee.rest.api.model.UpdateCategoryEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.security.utils.ImageUtils;
 import io.gravitee.rest.api.service.CategoryService;
-import io.gravitee.rest.api.service.exceptions.UnauthorizedAccessException;
 import io.gravitee.rest.api.service.exceptions.CategoryNotFoundException;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.gravitee.rest.api.service.exceptions.UnauthorizedAccessException;
+import io.swagger.annotations.*;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -50,8 +46,12 @@ import static io.gravitee.common.http.MediaType.APPLICATION_JSON;
 @Api(tags = {"Categories"})
 public class CategoryResource extends AbstractCategoryResource {
 
-    @Autowired
+    @Inject
     private CategoryService categoryService;
+
+    @PathParam("categoryId")
+    @ApiParam(name = "categoryId", required = true)
+    private String categoryId;
 
     @GET
     @Produces(APPLICATION_JSON)
@@ -60,7 +60,7 @@ public class CategoryResource extends AbstractCategoryResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "Category's definition", response = CategoryEntity.class),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public CategoryEntity get(@PathParam("id") String categoryId) {
+    public CategoryEntity getCategory() {
         boolean canShowCategory = hasPermission(RolePermission.ENVIRONMENT_CATEGORY, RolePermissionAction.READ);
         CategoryEntity category = categoryService.findById(categoryId);
 
@@ -80,9 +80,7 @@ public class CategoryResource extends AbstractCategoryResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "Category's picture"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Response picture(
-            @Context Request request,
-            @PathParam("id") String categoryId) throws CategoryNotFoundException {
+    public Response getCategoryPicture(@Context Request request) throws CategoryNotFoundException {
         boolean canShowCategory = hasPermission(RolePermission.ENVIRONMENT_CATEGORY, RolePermissionAction.READ);
         CategoryEntity category = categoryService.findById(categoryId);
 
@@ -134,7 +132,7 @@ public class CategoryResource extends AbstractCategoryResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_CATEGORY, acls = RolePermissionAction.UPDATE)
     })
-    public Response update(@PathParam("id") String categoryId, @Valid @NotNull final UpdateCategoryEntity category) {
+    public Response updateCategory(@Valid @NotNull final UpdateCategoryEntity category) {
         try {
             ImageUtils.verify(category.getPicture());
         } catch (InvalidImageException e) {
@@ -157,8 +155,8 @@ public class CategoryResource extends AbstractCategoryResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_CATEGORY, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("id") String id) {
-        categoryService.delete(id);
+    public void deleteCategory() {
+        categoryService.delete(categoryId);
     }
 
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ConfigurationResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ConfigurationResource.java
@@ -68,7 +68,7 @@ public class ConfigurationResource {
     @Path("/hooks")
     @ApiOperation("Get the list of available hooks")
     @Produces(MediaType.APPLICATION_JSON)
-    public Hook[] getHooks() {
+    public Hook[] getConfigurationHooks() {
         return Arrays.stream(PortalHook.values()).filter(h -> !h.isHidden()).toArray(Hook[]::new);
     }
 
@@ -82,7 +82,7 @@ public class ConfigurationResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_NOTIFICATION, acls = RolePermissionAction.READ)
     })
-    public List<NotifierEntity> getNotifiers() {
+    public List<NotifierEntity> getPortalNotifiers() {
         return notifierService.list(NotificationReferenceType.PORTAL, PortalNotificationDefaultReferenceId.DEFAULT.name());
     }
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CurrentUserResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/CurrentUserResource.java
@@ -41,12 +41,12 @@ import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
+import javax.inject.Inject;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -80,19 +80,19 @@ public class CurrentUserResource extends AbstractResource {
 
     private static Logger LOG = LoggerFactory.getLogger(CurrentUserResource.class);
 
-    @Autowired
+    @Inject
     private UserService userService;
     @Context
     private HttpServletResponse response;
-    @Autowired
+    @Inject
     private TaskService taskService;
     @Context
     private ResourceContext resourceContext;
-    @Autowired
+    @Inject
     private ConfigurableEnvironment environment;
-    @Autowired
+    @Inject
     private CookieGenerator cookieGenerator;
-    @Autowired
+    @Inject
     private TagService tagService;
 
     @GET
@@ -169,7 +169,7 @@ public class CurrentUserResource extends AbstractResource {
 
         if (isAuthenticated()) {
             userService.delete(getAuthenticatedUser());
-            logout();
+            logoutCurrentUser();
             return Response.noContent().build();
         } else {
             return Response.status(Response.Status.UNAUTHORIZED).build();
@@ -303,7 +303,7 @@ public class CurrentUserResource extends AbstractResource {
     @POST
     @Path("/logout")
     @ApiOperation(value = "Logout")
-    public Response logout() {
+    public Response logoutCurrentUser() {
         response.addCookie(cookieGenerator.generate(TokenAuthenticationFilter.AUTH_COOKIE_NAME, null));
         return Response.ok().build();
     }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/DashboardsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/DashboardsResource.java
@@ -30,8 +30,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -44,7 +44,7 @@ import java.util.List;
 @Api(tags = {"Dashboards"})
 public class DashboardsResource extends AbstractResource  {
 
-    @Autowired
+    @Inject
     private DashboardService dashboardService;
 
     @GET
@@ -53,7 +53,7 @@ public class DashboardsResource extends AbstractResource  {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List of platform dashboards", response = DashboardEntity.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<DashboardEntity> list(final @QueryParam("reference_type") DashboardReferenceType referenceType)  {
+    public List<DashboardEntity> getDashboards(final @QueryParam("reference_type") DashboardReferenceType referenceType)  {
         if (!hasPermission(RolePermission.ENVIRONMENT_DASHBOARD, RolePermissionAction.READ) &&
             !canReadAPIConfiguration()) {
             throw new ForbiddenAccessException();
@@ -76,7 +76,7 @@ public class DashboardsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = RolePermissionAction.CREATE)
     })
-    public DashboardEntity create(@Valid @NotNull final NewDashboardEntity dashboard) {
+    public DashboardEntity createDashboard(@Valid @NotNull final NewDashboardEntity dashboard) {
         return dashboardService.create(dashboard);
     }
 
@@ -91,7 +91,7 @@ public class DashboardsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = RolePermissionAction.READ)
     })
-    public DashboardEntity get(final @PathParam("dashboardId") String dashboardId)  {
+    public DashboardEntity getDashboard(final @PathParam("dashboardId") String dashboardId)  {
         return dashboardService.findById(dashboardId);
     }
 
@@ -107,7 +107,7 @@ public class DashboardsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = RolePermissionAction.UPDATE)
     })
-    public DashboardEntity update(@PathParam("dashboardId") String dashboardId, @Valid @NotNull final UpdateDashboardEntity dashboard) {
+    public DashboardEntity updateDashboard(@PathParam("dashboardId") String dashboardId, @Valid @NotNull final UpdateDashboardEntity dashboard) {
         dashboard.setId(dashboardId);
         return dashboardService.update(dashboard);
     }
@@ -123,7 +123,7 @@ public class DashboardsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_DASHBOARD, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("dashboardId") String dashboardId) {
+    public void deleteDashboard(@PathParam("dashboardId") String dashboardId) {
         dashboardService.delete(dashboardId);
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EntrypointsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EntrypointsResource.java
@@ -28,8 +28,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -44,7 +44,7 @@ import static java.util.stream.Collectors.toList;
 @Api(tags = {"Entrypoints"})
 public class EntrypointsResource extends AbstractResource  {
 
-    @Autowired
+    @Inject
     private EntrypointService entrypointService;
 
     @GET
@@ -59,7 +59,7 @@ public class EntrypointsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ENTRYPOINT, acls = RolePermissionAction.READ)
     })
-    public EntrypointEntity get(final @PathParam("entrypoint") String entrypointId)  {
+    public EntrypointEntity getEntrypoint(final @PathParam("entrypoint") String entrypointId)  {
         return entrypointService.findById(entrypointId);
     }
 
@@ -73,7 +73,7 @@ public class EntrypointsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ENTRYPOINT, acls = RolePermissionAction.READ)
     })
-    public List<EntrypointEntity> list()  {
+    public List<EntrypointEntity> getEntrypoints()  {
         return entrypointService.findAll()
                 .stream()
                 .sorted((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(o1.getValue(), o2.getValue()))
@@ -91,7 +91,7 @@ public class EntrypointsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ENTRYPOINT, acls = RolePermissionAction.CREATE)
     })
-    public EntrypointEntity create(@Valid @NotNull final NewEntryPointEntity entrypoint) {
+    public EntrypointEntity createEntrypoint(@Valid @NotNull final NewEntryPointEntity entrypoint) {
         return entrypointService.create(entrypoint);
     }
 
@@ -106,7 +106,7 @@ public class EntrypointsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ENTRYPOINT, acls = RolePermissionAction.UPDATE)
     })
-    public EntrypointEntity update(@Valid @NotNull final UpdateEntryPointEntity entrypoint) {
+    public EntrypointEntity updateEntrypoint(@Valid @NotNull final UpdateEntryPointEntity entrypoint) {
         return entrypointService.update(entrypoint);
     }
 
@@ -121,7 +121,7 @@ public class EntrypointsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ENTRYPOINT, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("entrypoint") String entrypoint) {
+    public void deleteEntrypoint(@PathParam("entrypoint") String entrypoint) {
         entrypointService.delete(entrypoint);
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentResource.java
@@ -20,6 +20,7 @@ import io.gravitee.rest.api.management.rest.resource.auth.OAuth2AuthenticationRe
 import io.gravitee.rest.api.management.rest.resource.search.SearchResource;
 import io.gravitee.rest.api.model.UpdateEnvironmentEntity;
 import io.gravitee.rest.api.service.EnvironmentService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
 
 import javax.inject.Inject;
@@ -57,18 +58,17 @@ public class EnvironmentResource extends AbstractResource {
             @ApiResponse(code = 201, message = "Environment successfully created"),
             @ApiResponse(code = 500, message = "Internal server error")})
     public Response createEnvironment(
-            @ApiParam(name = "environmentId", required = true) @PathParam("envId") String environmentId,
             @ApiParam(name = "environmentEntity", required = true) @Valid @NotNull final UpdateEnvironmentEntity environmentEntity) {
-        environmentEntity.setId(environmentId);
+        environmentEntity.setId(GraviteeContext.getCurrentEnvironment());
         return Response
                 .status(Status.CREATED)
                 .entity(environmentService.createOrUpdate(environmentEntity))
                 .build();
     }
-    
+
     /**
      * Delete an existing Environment.
-     * @param environmentId
+     *
      * @return
      */
     @DELETE
@@ -77,10 +77,8 @@ public class EnvironmentResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 204, message = "Environment successfully deleted"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Response deleteEnvironment(
-            @ApiParam(name = "environmentId", required = true)
-            @PathParam("envId") String environmentId) {
-        environmentService.delete(environmentId);
+    public Response deleteEnvironment() {
+        environmentService.delete(GraviteeContext.getCurrentEnvironment());
         //TODO: should delete all items that refers to this environment
         return Response
                 .status(Status.NO_CONTENT)
@@ -184,8 +182,8 @@ public class EnvironmentResource extends AbstractResource {
     }
 
     @Path("entrypoints")
-    public PortalEntryPointsResource getPortalEntryPointsResource() {
-        return resourceContext.getResource(PortalEntryPointsResource.class);
+    public PortalEntrypointsResource getPortalEntryPointsResource() {
+        return resourceContext.getResource(PortalEntrypointsResource.class);
     }
 
     @Path("notifiers")

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/EnvironmentsResource.java
@@ -16,8 +16,10 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiParam;
 
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.Context;
 
@@ -32,7 +34,9 @@ public class EnvironmentsResource extends AbstractResource {
     private ResourceContext resourceContext;
 
     @Path("{envId}")
-    public EnvironmentResource getEnvironmentResource() {
+    public EnvironmentResource getEnvironmentResource(
+            @PathParam("envId") @ApiParam(name = "envId", required = true, defaultValue = "DEFAULT", value = "The ID of the environment") String envId
+    ) {
         return resourceContext.getResource(EnvironmentResource.class);
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/FetchersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/FetchersResource.java
@@ -57,7 +57,7 @@ public class FetchersResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List of fetchers", response = FetcherListItem.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Collection<FetcherListItem> list(@BeanParam FetchersParam params) {
+    public Collection<FetcherListItem> getFetchers(@BeanParam FetchersParam params) {
         Stream<FetcherListItem> stream = fetcherService.findAll(params.isOnlyFilesFetchers()).stream().map(this::convert);
 
         if(params != null && params.getExpand() != null && !params.getExpand().isEmpty()) {

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GraviteeManagementApplication.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GraviteeManagementApplication.java
@@ -60,6 +60,7 @@ public class GraviteeManagementApplication extends ResourceConfig {
         beanConfig.setResourcePackage("io.gravitee.rest.api.management.rest.resource");
         beanConfig.setTitle("Gravitee.io - Management API");
         beanConfig.setScan(true);
+        beanConfig.setBasePath("/management");
 
         ModelConverters.getInstance().addConverter(new ModelConverter() {
             @Override

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupInvitationsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupInvitationsResource.java
@@ -16,11 +16,14 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
-import io.gravitee.rest.api.model.*;
-import io.gravitee.rest.api.model.permissions.RolePermission;
-import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
+import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.InvitationEntity;
+import io.gravitee.rest.api.model.NewInvitationEntity;
+import io.gravitee.rest.api.model.UpdateInvitationEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.InvitationService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
@@ -28,9 +31,9 @@ import io.gravitee.rest.api.service.exceptions.GroupInvitationForbiddenException
 import io.gravitee.rest.api.service.exceptions.GroupMembersLimitationExceededException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.DELETE;
@@ -49,10 +52,15 @@ import static io.gravitee.rest.api.service.exceptions.GroupInvitationForbiddenEx
 @Api(tags = {"Group Invitations"})
 public class GroupInvitationsResource extends AbstractResource {
 
-    @Autowired
+    @Inject
     private InvitationService invitationService;
-    @Autowired
+    @Inject
     private GroupService groupService;
+
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("group")
+    @ApiParam(name = "group", hidden = true)
+    private String group;
 
     @GET
     @ApiOperation(value = "List existing invitations of a group",
@@ -61,7 +69,7 @@ public class GroupInvitationsResource extends AbstractResource {
             @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = {READ, CREATE, UPDATE, DELETE}),
             @Permission(value = GROUP_INVITATION, acls = READ)
     })
-    public List<InvitationEntity> list(@PathParam("group") String group) {
+    public List<InvitationEntity> getGroupInvitations() {
         return invitationService.findByReference(GROUP, group);
     }
 
@@ -74,7 +82,7 @@ public class GroupInvitationsResource extends AbstractResource {
             @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = {UPDATE, CREATE}),
             @Permission(value = RolePermission.GROUP_INVITATION, acls = RolePermissionAction.CREATE)
     })
-    public InvitationEntity create(@PathParam("group") String group, @Valid @NotNull final NewInvitationEntity invitationEntity) {
+    public InvitationEntity createGroupInvitation(@Valid @NotNull final NewInvitationEntity invitationEntity) {
         // Check that group exists
         final GroupEntity groupEntity = groupService.findById(group);
         // check if user is a 'simple group admin' or a platform admin
@@ -105,7 +113,7 @@ public class GroupInvitationsResource extends AbstractResource {
             @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = {UPDATE, CREATE}),
             @Permission(value = RolePermission.GROUP_INVITATION, acls = RolePermissionAction.UPDATE)
     })
-    public InvitationEntity update(@PathParam("group") String group, @PathParam("invitation") String invitation,
+    public InvitationEntity updateGroupInvitation(@PathParam("invitation") String invitation,
                                    @Valid @NotNull final UpdateInvitationEntity invitationEntity) {
         invitationEntity.setId(invitation);
         invitationEntity.setReferenceType(GROUP);
@@ -122,7 +130,7 @@ public class GroupInvitationsResource extends AbstractResource {
             @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = {UPDATE, CREATE}),
             @Permission(value = RolePermission.GROUP_INVITATION, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("group") String group, @PathParam("invitation") String invitation) {
+    public void deleteGroupInvitation(@PathParam("invitation") String invitation) {
         invitationService.delete(invitation, group);
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMemberResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMemberResource.java
@@ -15,15 +15,12 @@
  */
 package io.gravitee.rest.api.management.rest.resource;
 
-import io.gravitee.rest.api.model.permissions.RolePermission;
-import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.GroupService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
@@ -45,6 +42,11 @@ public class GroupMemberResource extends AbstractResource {
     @Inject
     private GroupService groupService;
 
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("group")
+    @ApiParam(name = "group", hidden = true)
+    private String group;
+
     @DELETE
     @ApiOperation(value = "Remove a group member")
     @ApiResponses({
@@ -55,7 +57,7 @@ public class GroupMemberResource extends AbstractResource {
             @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.DELETE),
             @Permission(value = RolePermission.GROUP_MEMBER, acls = RolePermissionAction.DELETE)
     })
-    public Response deleteMember( @PathParam("group") String group, @PathParam("member") String userId) {
+    public Response deleteGroupMember(@PathParam("member") String userId) {
         groupService.deleteUserFromGroup(group, userId);
         
         return Response.ok().build();

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
@@ -28,10 +28,7 @@ import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.GroupInvitationForbiddenException;
 import io.gravitee.rest.api.service.exceptions.GroupMembersLimitationExceededException;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -59,7 +56,12 @@ public class GroupMembersResource extends AbstractResource {
     private ResourceContext resourceContext;
     @Inject
     private GroupService groupService;
-    
+
+    @SuppressWarnings("UnresolvedRestParam")
+    @PathParam("group")
+    @ApiParam(name = "group", hidden = true)
+    private String group;
+
     @GET
     @Produces(io.gravitee.common.http.MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List group members")
@@ -70,7 +72,7 @@ public class GroupMembersResource extends AbstractResource {
             @Permission(value = ENVIRONMENT_GROUP, acls = RolePermissionAction.READ),
             @Permission(value = RolePermission.GROUP_MEMBER, acls = RolePermissionAction.READ)
     })
-    public List<GroupMemberEntity> getMembers(@PathParam("group") String group) {
+    public List<GroupMemberEntity> getGroupMembers() {
         //check that group exists
         groupService.findById(group);
 
@@ -110,8 +112,7 @@ public class GroupMembersResource extends AbstractResource {
             @Permission(value = RolePermission.GROUP_MEMBER, acls = RolePermissionAction.CREATE),
             @Permission(value = RolePermission.GROUP_MEMBER, acls = RolePermissionAction.UPDATE),
     })
-    public Response addOrUpdateMember(
-            @PathParam("group") String group,
+    public Response addOrUpdateGroupMember(
             @Valid @NotNull final List<GroupMembership> memberships
     ) {
         // Check that group exists

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupsResource.java
@@ -15,14 +15,13 @@
  */
 package io.gravitee.rest.api.management.rest.resource;
 
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.GroupEntity;
 import io.gravitee.rest.api.model.NewGroupEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.management.rest.security.Permission;
-import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.service.GroupService;
-import io.gravitee.rest.api.service.MembershipService;
 import io.swagger.annotations.*;
 
 import javax.inject.Inject;
@@ -48,9 +47,6 @@ public class GroupsResource extends AbstractResource {
     @Inject
     private GroupService groupService;
 
-    @Inject
-    private MembershipService membershipService;
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(
@@ -66,7 +62,7 @@ public class GroupsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_GROUP, acls = RolePermissionAction.READ)
     })
-    public Response findAll(){
+    public Response getGroups() {
         return Response
                 .ok(groupService.findAll())
                 .build();

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/InstancesResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/InstancesResource.java
@@ -56,7 +56,7 @@ public class InstancesResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_INSTANCE, acls = RolePermissionAction.READ)
     })
-    public Page<InstanceListItem> listInstances(@BeanParam InstanceSearchParam param) {
+    public Page<InstanceListItem> getInstances(@BeanParam InstanceSearchParam param) {
         InstanceQuery query = new InstanceQuery();
         query.setIncludeStopped(param.isIncludeStopped());
         query.setFrom(param.getFrom());

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/MessagesResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/MessagesResource.java
@@ -26,8 +26,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Produces;
@@ -40,7 +40,7 @@ import javax.ws.rs.core.Response;
 @Api(tags = {"Messages"})
 public class MessagesResource extends AbstractResource {
 
-    @Autowired
+    @Inject
     private MessageService messageService;
 
     @POST
@@ -54,7 +54,7 @@ public class MessagesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_MESSAGE, acls = RolePermissionAction.CREATE)
     })
-    public Response create(final MessageEntity message) {
+    public Response createMessage(final MessageEntity message) {
         return Response.ok(messageService.create(message)).build();
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/MetadataResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/MetadataResource.java
@@ -28,8 +28,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -43,7 +43,7 @@ import java.util.List;
 @Api(tags = {"Metadata"})
 public class MetadataResource extends AbstractResource {
 
-    @Autowired
+    @Inject
     private MetadataService metadataService;
 
     @GET
@@ -56,7 +56,7 @@ public class MetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_METADATA, acls = RolePermissionAction.READ)
     })
-    public List<MetadataEntity> list() {
+    public List<MetadataEntity> getMetadatas() {
         return metadataService.findAllDefault();
     }
 
@@ -71,7 +71,7 @@ public class MetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_METADATA, acls = RolePermissionAction.CREATE)
     })
-    public MetadataEntity create(@Valid @NotNull final NewMetadataEntity metadata) {
+    public MetadataEntity createMetadata(@Valid @NotNull final NewMetadataEntity metadata) {
         return metadataService.create(metadata);
     }
 
@@ -86,7 +86,7 @@ public class MetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_METADATA, acls = RolePermissionAction.UPDATE)
     })
-    public MetadataEntity update(@Valid @NotNull final UpdateMetadataEntity metadata) {
+    public MetadataEntity updateMetadata(@Valid @NotNull final UpdateMetadataEntity metadata) {
         return metadataService.update(metadata);
     }
 
@@ -101,7 +101,7 @@ public class MetadataResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_METADATA, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("metadata") String metadata) {
+    public void deleteMetadata(@PathParam("metadata") String metadata) {
         metadataService.delete(metadata);
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/MonitoringResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/MonitoringResource.java
@@ -16,11 +16,11 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.monitoring.MonitoringData;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.management.rest.security.Permission;
-import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.service.MonitoringService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -47,7 +47,7 @@ public class MonitoringResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_PLATFORM, acls = RolePermissionAction.READ)
     })
-    public MonitoringData instanceMonitoring(
+    public MonitoringData getInstanceMonitoring(
             @PathParam("gatewayId") String gatewayId) {
         return monitoringService.findMonitoring(gatewayId);
     }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/NotifiersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/NotifiersResource.java
@@ -47,7 +47,6 @@ import java.util.stream.Stream;
  * @author David BRASSELY (david.brassely at graviteesource.com)
  * @author GraviteeSource Team
  */
-@Path("/notifiers")
 @Api(tags = {"Plugins"})
 public class NotifiersResource {
 
@@ -67,7 +66,7 @@ public class NotifiersResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.READ)
     })
-    public Collection<NotifierListItem> listNotifiers(@QueryParam("expand") List<String> expand) {
+    public Collection<NotifierListItem> getNotifiers(@QueryParam("expand") List<String> expand) {
         Stream<NotifierListItem> stream = notifierService.findAll().stream().map(this::convert);
 
         if(expand!=null && !expand.isEmpty()) {

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/OrganizationResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/OrganizationResource.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.rest.resource;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.model.UpdateOrganizationEntity;
 import io.gravitee.rest.api.service.OrganizationService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
 
 import javax.inject.Inject;
@@ -35,7 +36,7 @@ import javax.ws.rs.core.Response.Status;
  */
 @Api
 public class OrganizationResource extends AbstractResource {
-    
+
     @Context
     private ResourceContext resourceContext;
 
@@ -44,7 +45,7 @@ public class OrganizationResource extends AbstractResource {
 
     /**
      * Create or update an Organization for the authenticated user.
-     * 
+     *
      * @param organizationEntity
      * @return
      */
@@ -55,17 +56,15 @@ public class OrganizationResource extends AbstractResource {
     @ApiResponses({ @ApiResponse(code = 201, message = "Organization successfully created"),
             @ApiResponse(code = 500, message = "Internal server error") })
     public Response createOrganization(
-            @ApiParam(name = "organizationId", required = true) @PathParam("orgId") String organizationId,
             @ApiParam(name = "organizationEntity", required = true) @Valid @NotNull final UpdateOrganizationEntity organizationEntity) {
-        organizationEntity.setId(organizationId);
+        organizationEntity.setId(GraviteeContext.getCurrentOrganization());
         return Response
                 .ok(organizationService.createOrUpdate(organizationEntity))
                 .build();
     }
-    
+
     /**
      * Delete an existing Organization.
-     * @param organizationId
      * @return
      */
     @DELETE
@@ -74,8 +73,8 @@ public class OrganizationResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 204, message = "Organization successfully deleted"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Response deleteOrganization(@ApiParam(name = "organizationId", required = true) @PathParam("orgId") String organizationId) {
-        organizationService.delete(organizationId);
+    public Response deleteOrganization() {
+        organizationService.delete(GraviteeContext.getCurrentOrganization());
         //TODO: should delete all items that refers to this organization
         return Response
                 .status(Status.NO_CONTENT)
@@ -86,7 +85,7 @@ public class OrganizationResource extends AbstractResource {
     public UsersResource getUsersResource() {
         return resourceContext.getResource(UsersResource.class);
     }
-    
+
     @Path("configuration/rolescopes/{scope}/roles/{role}/users")
     public RoleUsersResource getRoleUsersResource() {
         return resourceContext.getResource(RoleUsersResource.class);

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/OrganizationsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/OrganizationsResource.java
@@ -16,8 +16,10 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiParam;
 
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.Context;
 
@@ -33,7 +35,9 @@ public class OrganizationsResource extends AbstractResource {
     private ResourceContext resourceContext;
 
     @Path("/{orgId}")
-    public OrganizationResource getOrganizationResource() {
+    public OrganizationResource getOrganizationResource(
+            @PathParam("orgId") @ApiParam(name = "orgId", required = true, defaultValue = "DEFAULT", value = "The ID of the Organization") String orgId
+    ) {
         return resourceContext.getResource(OrganizationResource.class);
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlansResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlansResource.java
@@ -22,8 +22,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
@@ -39,7 +39,7 @@ public class PlansResource extends AbstractResource  {
     @Context
     private UriInfo uriInfo;
 
-    @Autowired
+    @Inject
     private PlanService planService;
 
     @GET
@@ -48,7 +48,7 @@ public class PlansResource extends AbstractResource  {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List of plans", response = PlansConfigurationEntity.class),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public PlansConfigurationEntity getConfiguration() {
+    public PlansConfigurationEntity getPlansConfiguration() {
         return planService.getConfiguration();
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAlertsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAlertsResource.java
@@ -29,8 +29,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -49,7 +49,7 @@ public class PlatformAlertsResource extends AbstractResource {
 
     private final static String PLATFORM_REFERENCE_ID = "default";
 
-    @Autowired
+    @Inject
     private AlertService alertService;
 
     @GET
@@ -62,7 +62,7 @@ public class PlatformAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ALERT, acls = READ)
     })
-    public List<AlertTriggerEntity> list() {
+    public List<AlertTriggerEntity> getPlatformAlerts() {
         return alertService.findByReference(PLATFORM, PLATFORM_REFERENCE_ID);
     }
 
@@ -77,7 +77,7 @@ public class PlatformAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ALERT, acls = READ)
     })
-    public AlertStatusEntity status() {
+    public AlertStatusEntity getPlatformAlertStatus() {
         return alertService.getStatus();
     }
 
@@ -92,7 +92,7 @@ public class PlatformAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ALERT, acls = RolePermissionAction.CREATE)
     })
-    public AlertTriggerEntity create(@Valid @NotNull final NewAlertTriggerEntity alertEntity) {
+    public AlertTriggerEntity createPlatformAlert(@Valid @NotNull final NewAlertTriggerEntity alertEntity) {
         alertEntity.setReferenceType(PLATFORM);
         alertEntity.setReferenceId(PLATFORM_REFERENCE_ID);
         return alertService.create(alertEntity);
@@ -110,7 +110,7 @@ public class PlatformAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ALERT, acls = RolePermissionAction.UPDATE)
     })
-    public AlertTriggerEntity update(@PathParam("alert") String alert, @Valid @NotNull final UpdateAlertTriggerEntity alertEntity) {
+    public AlertTriggerEntity updatePlatformAlert(@PathParam("alert") String alert, @Valid @NotNull final UpdateAlertTriggerEntity alertEntity) {
         alertEntity.setId(alert);
         alertEntity.setReferenceType(PLATFORM);
         alertEntity.setReferenceId(PLATFORM_REFERENCE_ID);
@@ -127,7 +127,7 @@ public class PlatformAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ALERT, acls = RolePermissionAction.UPDATE)
     })
-    public Response associate(@PathParam("alert") String alert, @QueryParam("type") String type) {
+    public Response associatePlatformAlert(@PathParam("alert") String alert, @QueryParam("type") String type) {
         alertService.applyDefaults(alert, AlertReferenceType.valueOf(type.toUpperCase()));
         return Response.ok().build();
     }
@@ -144,7 +144,7 @@ public class PlatformAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ALERT, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("alert") String alert) {
+    public void deletePlatformAlert(@PathParam("alert") String alert) {
         alertService.delete(alert, PLATFORM_REFERENCE_ID);
     }
 
@@ -159,7 +159,7 @@ public class PlatformAlertsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_ALERT, acls = READ)
     })
-    public Page<AlertEventEntity> listEvents(@PathParam("alert") String alert, @BeanParam AlertEventSearchParam param) {
+    public Page<AlertEventEntity> getPlatformAlertEvents(@PathParam("alert") String alert, @BeanParam AlertEventSearchParam param) {
         return alertService.findEvents(
                 alert,
                 new AlertEventQuery.Builder()

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformAnalyticsResource.java
@@ -77,7 +77,7 @@ public class PlatformAnalyticsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = ENVIRONMENT_PLATFORM, acls = READ)
     })
-    public Response platformAnalytics(@BeanParam AnalyticsParam analyticsParam) {
+    public Response getPlatformAnalytics(@BeanParam AnalyticsParam analyticsParam) {
 
         analyticsParam.validate();
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformEventsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformEventsResource.java
@@ -67,7 +67,7 @@ public class PlatformEventsResource  extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_PLATFORM, acls = RolePermissionAction.READ)
     })
-    public Page<EventEntity> listEvents(@BeanParam EventSearchParam eventSearchParam) {
+    public Page<EventEntity> getPlatformEvents(@BeanParam EventSearchParam eventSearchParam) {
         eventSearchParam.validate();
 
         Map<String, Object> properties = new HashMap<>();

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformLogsResource.java
@@ -16,14 +16,14 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.resource.param.LogsParam;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.analytics.query.LogQuery;
 import io.gravitee.rest.api.model.log.ApiRequest;
 import io.gravitee.rest.api.model.log.SearchLogResponse;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.management.rest.resource.param.LogsParam;
-import io.gravitee.rest.api.management.rest.security.Permission;
-import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.service.LogsService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -58,7 +58,7 @@ public class PlatformLogsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_PLATFORM, acls = RolePermissionAction.READ)
     })
-    public SearchLogResponse platformLogs(
+    public SearchLogResponse getPlatformLogs(
             @BeanParam LogsParam param) {
         param.validate();
 
@@ -85,7 +85,7 @@ public class PlatformLogsResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_PLATFORM, acls = RolePermissionAction.READ)
     })
-    public ApiRequest platformLog(
+    public ApiRequest getPlatformLog(
             @PathParam("log") String logId,
             @QueryParam("timestamp") Long timestamp) {
         return logsService.findApiLog(logId, timestamp);
@@ -102,7 +102,7 @@ public class PlatformLogsResource extends AbstractResource {
     @Permissions({@Permission(value = RolePermission.ENVIRONMENT_PLATFORM, acls = RolePermissionAction.READ)})
     public Response exportPlatformLogsAsCSV(
             @BeanParam LogsParam param) {
-        final SearchLogResponse searchLogResponse = platformLogs(param);
+        final SearchLogResponse searchLogResponse = getPlatformLogs(param);
         return Response
                 .ok(logsService.exportAsCsv(searchLogResponse))
                 .header(HttpHeaders.CONTENT_DISPOSITION, format("attachment;filename=logs-%s-%s.csv", "platform", System.currentTimeMillis()))

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformTicketsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PlatformTicketsResource.java
@@ -48,7 +48,7 @@ public class PlatformTicketsResource extends AbstractResource  {
             @ApiResponse(code = 201, message = "Ticket succesfully created"),
             @ApiResponse(code = 500, message = "Internal server error")})
 
-    public Response create(@Valid @NotNull final NewTicketEntity ticketEntity) {
+    public Response createPlatformTicket(@Valid @NotNull final NewTicketEntity ticketEntity) {
         ticketService.create(getAuthenticatedUser(), ticketEntity);
         return Response.created(URI.create("")).build();
     }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PoliciesResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PoliciesResource.java
@@ -66,7 +66,7 @@ public class PoliciesResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.READ)
     })
-    public Collection<PolicyListItem> listPolicies(@QueryParam("expand") List<String> expand) {
+    public Collection<PolicyListItem> getPolicies(@QueryParam("expand") List<String> expand) {
         Stream<PolicyListItem> stream = policyService.findAll().stream().map(this::convert);
 
         if(expand!=null && !expand.isEmpty()) {

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalEntrypointsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalEntrypointsResource.java
@@ -20,10 +20,8 @@ import io.gravitee.rest.api.model.EntrypointEntity;
 import io.gravitee.rest.api.service.EntrypointService;
 import io.swagger.annotations.Api;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
+import javax.inject.Inject;
 import javax.ws.rs.GET;
-import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import java.util.List;
 
@@ -34,14 +32,14 @@ import static java.util.stream.Collectors.toList;
  * @author GraviteeSource Team
  */
 @Api(tags = {"Portal entrypoints"})
-public class PortalEntryPointsResource extends AbstractResource  {
+public class PortalEntrypointsResource extends AbstractResource  {
 
-    @Autowired
+    @Inject
     private EntrypointService entrypointService;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public List<EntrypointEntity> list()  {
+    public List<EntrypointEntity> getPortalEntrypoints()  {
         return entrypointService.findAll().stream()
                 .peek(entrypointEntity -> entrypointEntity.setId(null))
                 .collect(toList());

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalMediaResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalMediaResource.java
@@ -57,7 +57,7 @@ public class PortalMediaResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "Media successfully created"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Response upload(
+    public Response uploadPortalMedia(
             @FormDataParam("file") InputStream uploadedInputStream,
             @FormDataParam("file") FormDataContentDisposition fileDetail,
             @FormDataParam("file") final FormDataBodyPart body
@@ -91,7 +91,7 @@ public class PortalMediaResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "A media"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Response getImage(
+    public Response getPortalMedia(
             @Context Request request,
             @PathParam("hash") String hash) {
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalNotificationSettingsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalNotificationSettingsResource.java
@@ -28,8 +28,8 @@ import io.gravitee.rest.api.service.PortalNotificationConfigService;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
@@ -46,10 +46,10 @@ import static io.gravitee.rest.api.model.permissions.RolePermissionAction.*;
 @Api(tags = {"Portal Notifications"})
 public class PortalNotificationSettingsResource extends AbstractResource {
 
-    @Autowired
+    @Inject
     private PortalNotificationConfigService portalNotificationConfigService;
 
-    @Autowired
+    @Inject
     private GenericNotificationConfigService genericNotificationConfigService;
 
     @GET
@@ -58,7 +58,7 @@ public class PortalNotificationSettingsResource extends AbstractResource {
     @Permissions({
             @Permission(value = ENVIRONMENT_NOTIFICATION, acls = READ)
     })
-    public List<Object> get() {
+    public List<Object> getPortalNotificationSettings() {
         List<Object> settings = new ArrayList<>();
         settings.add(portalNotificationConfigService.findById(getAuthenticatedUser(), NotificationReferenceType.PORTAL, PortalNotificationDefaultReferenceId.DEFAULT.name()));
         if (hasPermission(ENVIRONMENT_NOTIFICATION, CREATE, UPDATE, DELETE)){
@@ -71,7 +71,7 @@ public class PortalNotificationSettingsResource extends AbstractResource {
     @ApiOperation(value = "Create notification settings")
     @Produces(MediaType.APPLICATION_JSON)
     @Consumes(MediaType.APPLICATION_JSON)
-    public Object create(GenericNotificationConfigEntity config) {
+    public Object createPortalNotificationSetting(GenericNotificationConfigEntity config) {
         if (!NotificationReferenceType.PORTAL.name().equals(config.getReferenceType())) {
             throw new ForbiddenAccessException();
         }
@@ -93,7 +93,7 @@ public class PortalNotificationSettingsResource extends AbstractResource {
     @Permissions({
             @Permission(value = ENVIRONMENT_NOTIFICATION, acls = UPDATE)
     })
-    public GenericNotificationConfigEntity update(
+    public GenericNotificationConfigEntity updateGenericNotificationSettings(
             @PathParam("notificationId") String notificationId,
             GenericNotificationConfigEntity config) {
         if (!PortalNotificationDefaultReferenceId.DEFAULT.name().equals(config.getReferenceId())
@@ -112,7 +112,7 @@ public class PortalNotificationSettingsResource extends AbstractResource {
     @Permissions({
             @Permission(value = ENVIRONMENT_NOTIFICATION, acls = READ)
     })
-    public PortalNotificationConfigEntity update(
+    public PortalNotificationConfigEntity updatePortalNotificationSettings(
             PortalNotificationConfigEntity config) {
         if (!PortalNotificationDefaultReferenceId.DEFAULT.name().equals(config.getReferenceId())
                 || !NotificationReferenceType.PORTAL.name().equals(config.getReferenceType())
@@ -131,7 +131,7 @@ public class PortalNotificationSettingsResource extends AbstractResource {
     @Permissions({
             @Permission(value = ENVIRONMENT_NOTIFICATION, acls = DELETE)
     })
-    public Response delete(
+    public Response deleteNotificationSettings(
             @PathParam("notificationId") String notificationId) {
         genericNotificationConfigService.delete(notificationId);
         return Response.noContent().build();

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalPagesResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/PortalPagesResource.java
@@ -64,13 +64,13 @@ public class PortalPagesResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "Page"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public PageEntity getPage(
+    public PageEntity getPortalPage(
                 @HeaderParam("Accept-Language") String acceptLang,
                 @PathParam("page") String page,
                 @QueryParam("portal") boolean portal,
                 @QueryParam("translated") boolean translated) {
         final String acceptedLocale = HttpHeadersUtil.getFirstAcceptedLocaleName(acceptLang);
-        PageEntity pageEntity = pageService.findById(page, translated?acceptedLocale:null);
+        PageEntity pageEntity = pageService.findById(page, translated ? acceptedLocale : null);
         if (isDisplayable(pageEntity.isPublished(), pageEntity.getExcludedGroups())) {
             if (!isAuthenticated() && pageEntity.getMetadata() != null) {
                 pageEntity.getMetadata().clear();
@@ -91,7 +91,7 @@ public class PortalPagesResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "Page's content"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Response getPageContent(
+    public Response getPortalPageContent(
             @PathParam("page") String page) {
         PageEntity pageEntity = pageService.findById(page);
         pageService.transformSwagger(pageEntity);
@@ -109,7 +109,7 @@ public class PortalPagesResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List of pages", response = PageEntity.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<PageEntity> listPages(
+    public List<PageEntity> getPortalPages(
             @HeaderParam("Accept-Language") String acceptLang,
             @QueryParam("homepage") Boolean homepage,
             @QueryParam("type") PageType type,
@@ -143,9 +143,9 @@ public class PortalPagesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.CREATE)
     })
-    public Response createPage(
+    public Response createPortalPage(
             @ApiParam(name = "page", required = true) @Valid @NotNull NewPageEntity newPageEntity) {
-        if(newPageEntity.getType().equals(PageType.SYSTEM_FOLDER)) {
+        if (newPageEntity.getType().equals(PageType.SYSTEM_FOLDER)) {
             throw new PageSystemFolderActionException("Create");
         }
         int order = pageService.findMaxPortalPageOrder() + 1;
@@ -174,11 +174,11 @@ public class PortalPagesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.UPDATE)
     })
-    public PageEntity updatePage(
+    public PageEntity updatePortalPage(
             @PathParam("page") String page,
             @ApiParam(name = "page", required = true) @Valid @NotNull UpdatePageEntity updatePageEntity) {
         PageEntity existingPage = pageService.findById(page);
-        if(existingPage.getType().equals(PageType.SYSTEM_FOLDER.name())) {
+        if (existingPage.getType().equals(PageType.SYSTEM_FOLDER.name())) {
             throw new PageSystemFolderActionException("Update");
         }
         updatePageEntity.setLastContributor(getAuthenticatedUser());
@@ -221,11 +221,11 @@ public class PortalPagesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.UPDATE)
     })
-    public PageEntity partialUpdatePage(
+    public PageEntity partialUpdatePortalPage(
             @PathParam("page") String page,
             @ApiParam(name = "page", required = true) @NotNull UpdatePageEntity updatePageEntity) {
-        PageEntity existingPage =pageService.findById(page);
-        if(existingPage.getType().equals(PageType.SYSTEM_FOLDER.name())) {
+        PageEntity existingPage = pageService.findById(page);
+        if (existingPage.getType().equals(PageType.SYSTEM_FOLDER.name())) {
             throw new PageSystemFolderActionException("Update");
         }
         updatePageEntity.setLastContributor(getAuthenticatedUser());
@@ -243,12 +243,11 @@ public class PortalPagesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.UPDATE)
     })
-    public PageEntity fetchPage(
-    @PathParam("page") String page) {
-            pageService.findById(page);
-            String contributor = getAuthenticatedUser();
+    public PageEntity fetchPortalPage(@PathParam("page") String page) {
+        pageService.findById(page);
+        String contributor = getAuthenticatedUser();
 
-            return pageService.fetch(page, contributor);
+        return pageService.fetch(page, contributor);
     }
 
     @POST
@@ -262,7 +261,7 @@ public class PortalPagesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.UPDATE)
     })
-    public Response fetchAllPages() {
+    public Response fetchAllPortalPages() {
         String contributor = getAuthenticatedUser();
         pageService.fetchAll(new PageQuery.Builder().build(), contributor);
         return Response.noContent().build();
@@ -278,10 +277,10 @@ public class PortalPagesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.DELETE)
     })
-    public void deletePage(
+    public void deletePortalPage(
             @PathParam("page") String page) {
         PageEntity existingPage = pageService.findById(page);
-        if(existingPage.getType().equals(PageType.SYSTEM_FOLDER.name())) {
+        if (existingPage.getType().equals(PageType.SYSTEM_FOLDER.name())) {
             throw new PageSystemFolderActionException("Delete");
         }
         pageService.delete(page);
@@ -299,7 +298,7 @@ public class PortalPagesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.CREATE)
     })
-    public List<PageEntity> importFiles(
+    public List<PageEntity> importPortalPageFromFiles(
             @ApiParam(name = "page", required = true) @Valid @NotNull ImportPageEntity importPageEntity) {
         importPageEntity.setLastContributor(getAuthenticatedUser());
         return pageService.importFiles(importPageEntity);
@@ -317,7 +316,7 @@ public class PortalPagesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_DOCUMENTATION, acls = RolePermissionAction.CREATE)
     })
-    public List<PageEntity> updateImportFiles(
+    public List<PageEntity> updateImportedPortalPageFromFiles(
             @ApiParam(name = "page", required = true) @Valid @NotNull ImportPageEntity importPageEntity) {
         importPageEntity.setLastContributor(getAuthenticatedUser());
         return pageService.importFiles(importPageEntity);

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ResourcesResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ResourcesResource.java
@@ -65,7 +65,7 @@ public class ResourcesResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.READ)
     })
-    public Collection<ResourceListItem> listResources(@QueryParam("expand") List<String> expand) {
+    public Collection<ResourceListItem> getResources(@QueryParam("expand") List<String> expand) {
         Stream<ResourceListItem> stream = resourceService.findAll().stream().map(this::convert);
 
         if(expand!=null && !expand.isEmpty()) {

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/RoleResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/RoleResource.java
@@ -29,8 +29,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -48,7 +48,7 @@ public class RoleResource extends AbstractResource  {
     @Context
     private ResourceContext resourceContext;
 
-    @Autowired
+    @Inject
     private RoleService roleService;
 
     @GET
@@ -63,7 +63,7 @@ public class RoleResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ORGANIZATION_ROLE, acls = RolePermissionAction.READ)
     })
-    public RoleEntity get(@PathParam("scope")RoleScope scope,
+    public RoleEntity getRole(@PathParam("scope")RoleScope scope,
                           @PathParam("role") String role) {
         Optional<RoleEntity> optRole = roleService.findByScopeAndName(scope, role);
         if(optRole.isPresent()) {
@@ -85,7 +85,7 @@ public class RoleResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ORGANIZATION_ROLE, acls = RolePermissionAction.UPDATE)
     })
-    public RoleEntity update(@PathParam("scope")RoleScope scope,
+    public RoleEntity updateRole(@PathParam("scope")RoleScope scope,
                              @PathParam("role") String role,
                              @Valid @NotNull final UpdateRoleEntity entity) {
         return roleService.update(entity);
@@ -103,7 +103,7 @@ public class RoleResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ORGANIZATION_ROLE, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("scope")RoleScope scope,
+    public void deleteRole(@PathParam("scope")RoleScope scope,
                        @PathParam("role") String role) {
         roleService.findByScopeAndName(scope, role).ifPresent(roleToDelete -> roleService.delete(roleToDelete.getId()));
     }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/RoleScopeResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/RoleScopeResource.java
@@ -28,8 +28,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -42,12 +42,12 @@ import java.util.List;
  * @author GraviteeSource Team
  */
 @Api(tags = {"Roles"})
-public class RoleScopeResource extends AbstractResource  {
+public class RoleScopeResource extends AbstractResource {
 
     @Context
     private ResourceContext resourceContext;
 
-    @Autowired
+    @Inject
     private RoleService roleService;
 
     @GET
@@ -60,7 +60,7 @@ public class RoleScopeResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ORGANIZATION_ROLE, acls = RolePermissionAction.READ)
     })
-    public List<RoleEntity> list(@PathParam("scope") RoleScope scope)  {
+    public List<RoleEntity> getRoles(@PathParam("scope") RoleScope scope) {
         return roleService.findByScope(scope);
     }
 
@@ -75,7 +75,8 @@ public class RoleScopeResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ORGANIZATION_ROLE, acls = RolePermissionAction.CREATE)
     })
-    public RoleEntity create(@PathParam("scope") RoleScope scope, @Valid @NotNull final NewRoleEntity role) {        return roleService.create(role);
+    public RoleEntity createRole(@PathParam("scope") RoleScope scope, @Valid @NotNull final NewRoleEntity role) {
+        return roleService.create(role);
     }
 
     @Path("{role}")

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/RoleScopesResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/RoleScopesResource.java
@@ -54,7 +54,7 @@ public class RoleScopesResource extends AbstractResource  {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List of role scopes"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Map<String, List<String>> list()  {
+    public Map<String, List<String>> getRoleScopes() {
         final Map<String, List<String>> roles = new LinkedHashMap<>(4);
         roles.put(RoleScope.ORGANIZATION.name(), stream(OrganizationPermission.values()).map(OrganizationPermission::getName).sorted().collect(toList()));
         roles.put(RoleScope.ENVIRONMENT.name(), stream(EnvironmentPermission.values()).map(EnvironmentPermission::getName).sorted().collect(toList()));

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/RoleUserResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/RoleUserResource.java
@@ -29,8 +29,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.PathParam;
@@ -42,7 +42,7 @@ import javax.ws.rs.PathParam;
 @Api(tags = {"Roles"})
 public class RoleUserResource extends AbstractResource  {
 
-    @Autowired
+    @Inject
     private MembershipService membershipService;
 
     @DELETE
@@ -55,7 +55,7 @@ public class RoleUserResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ORGANIZATION_ROLE, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("scope")RoleScope scope,
+    public void deleteRoleForUser(@PathParam("scope")RoleScope scope,
                        @PathParam("role") String role,
                        @PathParam("userId") String userId) {
         if (RoleScope.ORGANIZATION.equals(scope)) {

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/RoleUsersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/RoleUsersResource.java
@@ -19,18 +19,15 @@ import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.management.rest.model.RoleMembership;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
-import io.gravitee.rest.api.model.MemberEntity;
-import io.gravitee.rest.api.model.MembershipMemberType;
-import io.gravitee.rest.api.model.MembershipReferenceType;
-import io.gravitee.rest.api.model.RoleEntity;
+import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.swagger.annotations.*;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -51,7 +48,7 @@ public class RoleUsersResource extends AbstractResource  {
     @Context
     private ResourceContext resourceContext;
 
-    @Autowired
+    @Inject
     private MembershipService membershipService;
 
     @GET
@@ -64,7 +61,7 @@ public class RoleUsersResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ORGANIZATION_ROLE, acls = RolePermissionAction.READ)
     })
-    public List<MembershipListItem> listUsersPerRole(
+    public List<MembershipListItem> getUsersPerRole(
             @PathParam("scope")RoleScope scope,
             @PathParam("role") String role) {
         if (RoleScope.ORGANIZATION.equals(scope) || RoleScope.ENVIRONMENT.equals(scope)) {
@@ -154,22 +151,5 @@ public class RoleUsersResource extends AbstractResource  {
     @Path("{userId}")
     public RoleUserResource getRoleUserResource() {
         return resourceContext.getResource(RoleUserResource.class);
-    }
-
-    private final static class MembershipListItem {
-
-        private final MemberEntity member;
-
-        public MembershipListItem(final MemberEntity member) {
-            this.member = member;
-        }
-
-        public String getId() {
-            return member.getId();
-        }
-
-        public String getDisplayName() {
-            return member.getDisplayName();
-        }
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ServicesDiscoveryResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ServicesDiscoveryResource.java
@@ -66,7 +66,7 @@ public class ServicesDiscoveryResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_API, acls = RolePermissionAction.READ)
     })
-    public Collection<ResourceListItem> listResources(@QueryParam("expand") List<String> expand) {
+    public Collection<ResourceListItem> getServicesDiscoverResources(@QueryParam("expand") List<String> expand) {
         Stream<ResourceListItem> stream = serviceDiscoveryService.findAll().stream().map(this::convert);
 
         if(expand!=null && !expand.isEmpty()) {

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/SubscriptionsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/SubscriptionsResource.java
@@ -20,7 +20,6 @@ import io.gravitee.rest.api.management.rest.model.Subscription;
 import io.gravitee.rest.api.model.ApplicationEntity;
 import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.SubscriptionEntity;
-import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.ApplicationService;
 import io.gravitee.rest.api.service.PlanService;
 import io.gravitee.rest.api.service.SubscriptionService;
@@ -52,16 +51,13 @@ public class SubscriptionsResource {
     @Inject
     private PlanService planService;
 
-    @Inject
-    private ApiService apiService;
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "List subscriptions for authenticated user")
     @ApiResponses({
             @ApiResponse(code = 200, message = "List of subscriptions", response = Subscription.class, responseContainer = "Set"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Set<Subscription> listUserSubscriptions(
+    public Set<Subscription> getUserSubscriptions(
             @QueryParam("application") String application,
             @QueryParam("plan") String plan) {
         return subscriptionService.findByApplicationAndPlan(application, plan)

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/TagsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/TagsResource.java
@@ -16,21 +16,20 @@
 package io.gravitee.rest.api.management.rest.resource;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.NewTagEntity;
 import io.gravitee.rest.api.model.TagEntity;
 import io.gravitee.rest.api.model.UpdateTagEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.management.rest.security.Permission;
-import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.service.TagService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 
-import org.springframework.beans.factory.annotation.Autowired;
-
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -43,9 +42,9 @@ import java.util.stream.Collectors;
  * @author GraviteeSource Team
  */
 @Api(tags = {"Sharding Tags"})
-public class TagsResource extends AbstractResource  {
+public class TagsResource extends AbstractResource {
 
-    @Autowired
+    @Inject
     private TagService tagService;
 
     @GET
@@ -54,7 +53,7 @@ public class TagsResource extends AbstractResource  {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List of sharding tags", response = TagEntity.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<TagEntity> list()  {
+    public List<TagEntity> getTags() {
         return tagService.findAll()
                 .stream()
                 .sorted((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(o1.getName(), o2.getName()))
@@ -87,7 +86,7 @@ public class TagsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_TAG, acls = RolePermissionAction.CREATE)
     })
-    public TagEntity create(@Valid @NotNull final NewTagEntity tag) {
+    public TagEntity createTag(@Valid @NotNull final NewTagEntity tag) {
         return tagService.create(tag);
     }
 
@@ -103,7 +102,7 @@ public class TagsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_TAG, acls = RolePermissionAction.UPDATE)
     })
-    public TagEntity update(@PathParam("tag") String tagId, @Valid @NotNull final UpdateTagEntity tag) {
+    public TagEntity updateTag(@PathParam("tag") String tagId, @Valid @NotNull final UpdateTagEntity tag) {
         return tagService.update(tag);
     }
 
@@ -118,7 +117,7 @@ public class TagsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_TAG, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("tag") String tag) {
+    public void deleteTag(@PathParam("tag") String tag) {
         tagService.delete(tag);
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/TenantsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/TenantsResource.java
@@ -28,8 +28,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 @Api(tags = {"Tenants"})
 public class TenantsResource extends AbstractResource  {
 
-    @Autowired
+    @Inject
     private TenantService tenantService;
 
     @GET
@@ -53,7 +53,7 @@ public class TenantsResource extends AbstractResource  {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List of tenants", response = TenantEntity.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<TenantEntity> list()  {
+    public List<TenantEntity> getTenants()  {
         return tenantService.findAll()
                 .stream()
                 .sorted((o1, o2) -> String.CASE_INSENSITIVE_ORDER.compare(o1.getName(), o2.getName()))
@@ -71,7 +71,7 @@ public class TenantsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_TENANT, acls = RolePermissionAction.CREATE)
     })
-    public List<TenantEntity> create(@Valid @NotNull final List<NewTenantEntity> tenant) {
+    public List<TenantEntity> createTenants(@Valid @NotNull final List<NewTenantEntity> tenant) {
         return tenantService.create(tenant);
     }
 
@@ -86,7 +86,7 @@ public class TenantsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_TENANT, acls = RolePermissionAction.UPDATE)
     })
-    public List<TenantEntity> update(@Valid @NotNull final List<UpdateTenantEntity> tenant) {
+    public List<TenantEntity> updateTenants(@Valid @NotNull final List<UpdateTenantEntity> tenant) {
         return tenantService.update(tenant);
     }
 
@@ -101,7 +101,7 @@ public class TenantsResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_TENANT, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("tenant") String tenant) {
+    public void deleteTenant(@PathParam("tenant") String tenant) {
         tenantService.delete(tenant);
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ThemeResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ThemeResource.java
@@ -27,8 +27,9 @@ import io.gravitee.rest.api.model.theme.ThemeEntity;
 import io.gravitee.rest.api.model.theme.UpdateThemeEntity;
 import io.gravitee.rest.api.service.ThemeService;
 import io.swagger.annotations.Api;
-import org.springframework.beans.factory.annotation.Autowired;
+import io.swagger.annotations.ApiParam;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -43,15 +44,19 @@ import java.net.URI;
 @Api(tags = {"Themes"})
 public class ThemeResource extends AbstractResource  {
 
-    @Autowired
+    @Inject
     private ThemeService themeService;
-
+    
+    @PathParam("themeId")
+    @ApiParam(name = "themeId", required=true)
+    private String themeId;
+    
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = RolePermissionAction.READ)
     })
-    public ThemeEntity get(final @PathParam("themeId") String themeId)  {
+    public ThemeEntity getTheme()  {
         return themeService.findEnabled();
     }
 
@@ -61,7 +66,7 @@ public class ThemeResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = RolePermissionAction.UPDATE)
     })
-    public ThemeEntity update(@PathParam("themeId") String themeId, @Valid @NotNull final UpdateThemeEntity theme) {
+    public ThemeEntity updateTheme(@Valid @NotNull final UpdateThemeEntity theme) {
         theme.setId(themeId);
         return themeService.update(theme);
     }
@@ -72,7 +77,7 @@ public class ThemeResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = RolePermissionAction.UPDATE)
     })
-    public ThemeEntity reset(@PathParam("themeId") String themeId) {
+    public ThemeEntity resetTheme() {
         return themeService.resetToDefaultTheme(themeId);
     }
 
@@ -81,26 +86,26 @@ public class ThemeResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("themeId") String themeId) {
+    public void deleteTheme() {
         themeService.delete(themeId);
     }
 
     @GET
     @Path("/logo")
-    public Response getLogo(@PathParam("themeId") String id, @Context Request request) {
-       return this.buildPictureResponse(themeService.getLogo(id), request);
+    public Response getThemeLogo(@Context Request request) {
+       return this.buildPictureResponse(themeService.getLogo(themeId), request);
     }
 
     @GET
     @Path("/optionalLogo")
-    public Response getLogoLight(@PathParam("themeId") String id, @Context Request request) {
-        return this.buildPictureResponse(themeService.getOptionalLogo(id), request);
+    public Response getLogoLight(@Context Request request) {
+        return this.buildPictureResponse(themeService.getOptionalLogo(themeId), request);
     }
 
     @GET
     @Path("/backgroundImage")
-    public Response getBackground(@PathParam("themeId") String id, @Context Request request) {
-        return this.buildPictureResponse(themeService.getBackgroundImage(id), request);
+    public Response getThemeBackground(@Context Request request) {
+        return this.buildPictureResponse(themeService.getBackgroundImage(themeId), request);
     }
 
     private Response buildPictureResponse(PictureEntity picture, @Context Request request) {

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ThemesResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ThemesResource.java
@@ -24,11 +24,14 @@ import io.gravitee.rest.api.model.theme.NewThemeEntity;
 import io.gravitee.rest.api.model.theme.ThemeEntity;
 import io.gravitee.rest.api.service.ThemeService;
 import io.swagger.annotations.Api;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.*;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.container.ResourceContext;
 import javax.ws.rs.core.Context;
 
@@ -42,7 +45,7 @@ public class ThemesResource extends AbstractResource {
     @Context
     private ResourceContext resourceContext;
 
-    @Autowired
+    @Inject
     private ThemeService themeService;
 
     @POST
@@ -51,7 +54,7 @@ public class ThemesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_THEME, acls = RolePermissionAction.CREATE)
     })
-    public ThemeEntity create(@Valid @NotNull final NewThemeEntity theme) {
+    public ThemeEntity createTheme(@Valid @NotNull final NewThemeEntity theme) {
         return themeService.create(theme);
     }
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/TokensResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/TokensResource.java
@@ -23,8 +23,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -40,7 +40,7 @@ import static java.util.stream.Collectors.toList;
 @Api(tags = {"User Tokens"})
 public class TokensResource extends AbstractResource  {
 
-    @Autowired
+    @Inject
     private TokenService tokenService;
 
     @GET
@@ -50,7 +50,7 @@ public class TokensResource extends AbstractResource  {
             @ApiResponse(code = 200, message = "User's personal tokens"),
             @ApiResponse(code = 404, message = "User not found"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<TokenEntity> list()  {
+    public List<TokenEntity> getTokens()  {
         return tokenService.findByUser(getAuthenticatedUser())
                 .stream()
                 .sorted(comparing(TokenEntity::getCreatedAt))
@@ -64,7 +64,7 @@ public class TokensResource extends AbstractResource  {
     @ApiResponses({
             @ApiResponse(code = 201, message = "A new personal token", response = TokenEntity.class),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public TokenEntity create(@Valid @NotNull final NewTokenEntity token) {
+    public TokenEntity createTokens(@Valid @NotNull final NewTokenEntity token) {
         return tokenService.create(token);
     }
 
@@ -75,7 +75,7 @@ public class TokensResource extends AbstractResource  {
             @ApiResponse(code = 204, message = "User's personal tokens revoked"),
             @ApiResponse(code = 404, message = "User not found"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public void revokeAll() {
+    public void revokeAllTokens() {
         tokenService.revokeByUser(getAuthenticatedUser());
     }
 
@@ -87,7 +87,7 @@ public class TokensResource extends AbstractResource  {
             @ApiResponse(code = 204, message = "User's personal token revoked"),
             @ApiResponse(code = 404, message = "User not found"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public void revoke(@PathParam("token") String tokenId) {
+    public void revokeToken(@PathParam("token") String tokenId) {
         tokenService.revoke(tokenId);
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/TopApisResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/TopApisResource.java
@@ -29,8 +29,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -52,7 +52,7 @@ public class TopApisResource extends AbstractResource  {
     @Context
     private UriInfo uriInfo;
 
-    @Autowired
+    @Inject
     private TopApiService topApiService;
 
     @GET
@@ -66,7 +66,7 @@ public class TopApisResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_TOP_APIS, acls = RolePermissionAction.READ)
     })
-    public List<TopApiEntity> list()  {
+    public List<TopApiEntity> getTopApis()  {
         return topApiService.findAll().stream()
                 .peek(addPictureUrl())
                 .collect(toList());
@@ -83,7 +83,7 @@ public class TopApisResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_TOP_APIS, acls = RolePermissionAction.CREATE)
     })
-    public List<TopApiEntity> create(@Valid @NotNull final NewTopApiEntity topApi) {
+    public List<TopApiEntity> createTopApi(@Valid @NotNull final NewTopApiEntity topApi) {
         return topApiService.create(topApi).stream()
                 .peek(addPictureUrl())
                 .collect(toList());
@@ -100,7 +100,7 @@ public class TopApisResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_TOP_APIS, acls = RolePermissionAction.UPDATE)
     })
-    public List<TopApiEntity> update(@Valid @NotNull final List<UpdateTopApiEntity> topApis) {
+    public List<TopApiEntity> updateTopApi(@Valid @NotNull final List<UpdateTopApiEntity> topApis) {
         return topApiService.update(topApis).stream()
                 .peek(addPictureUrl())
                 .collect(toList());
@@ -118,7 +118,7 @@ public class TopApisResource extends AbstractResource  {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_TOP_APIS, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("topAPI") String topAPI) {
+    public void deleteTopApi(@PathParam("topAPI") String topAPI) {
         topApiService.delete(topAPI);
     }
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/UserNotificationsResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/UserNotificationsResource.java
@@ -48,7 +48,7 @@ public class UserNotificationsResource extends AbstractResource  {
             @ApiResponse(code = 200, message = "User's notifications"),
             @ApiResponse(code = 404, message = "User not found"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public PagedResult<PortalNotificationEntity> list()  {
+    public PagedResult<PortalNotificationEntity> getUserNotifications()  {
         List<PortalNotificationEntity> notifications = portalNotificationService.findByUser(getAuthenticatedUser())
                 .stream()
                 .sorted(Comparator.comparing(PortalNotificationEntity::getCreatedAt))
@@ -63,7 +63,7 @@ public class UserNotificationsResource extends AbstractResource  {
             @ApiResponse(code = 204, message = "Notifications successfully deleted"),
             @ApiResponse(code = 404, message = "User not found"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Response deleteAll() {
+    public Response deleteAllUserNotifications() {
         portalNotificationService.deleteAll(getAuthenticatedUser());
         return Response
                 .status(Response.Status.NO_CONTENT)
@@ -77,7 +77,7 @@ public class UserNotificationsResource extends AbstractResource  {
             @ApiResponse(code = 204, message = "Notification successfully deleted"),
             @ApiResponse(code = 404, message = "User not found"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Response delete(@PathParam("notification") String notificationId) {
+    public Response deleteUserNotification(@PathParam("notification") String notificationId) {
         portalNotificationService.delete(notificationId);
         return Response
                 .status(Response.Status.NO_CONTENT)

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/UserResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/UserResource.java
@@ -23,10 +23,7 @@ import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.UserService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.*;
 
 import javax.inject.Inject;
 import javax.validation.Valid;
@@ -61,6 +58,10 @@ public class UserResource extends AbstractResource {
     @Inject
     private GroupService groupService;
 
+    @PathParam("userId")
+    @ApiParam(name = "userId", required = true)
+    private String userId;
+
     @GET
     @Produces(APPLICATION_JSON)
     @ApiOperation(value = "Retrieve a user",
@@ -72,7 +73,7 @@ public class UserResource extends AbstractResource {
     @Permissions(
             @Permission(value = RolePermission.ORGANIZATION_USERS, acls = RolePermissionAction.READ)
     )
-    public UserEntity getUser(@PathParam("id") String userId) {
+    public UserEntity getUser() {
         UserEntity user = userService.findByIdWithRoles(userId);
 
         // Delete password for security reason
@@ -92,7 +93,7 @@ public class UserResource extends AbstractResource {
     @Permissions(
             @Permission(value = RolePermission.ORGANIZATION_USERS, acls = RolePermissionAction.DELETE)
     )
-    public Response deleteUser(@PathParam("id") String userId) {
+    public Response deleteUser() {
         userService.delete(userId);
         return Response.noContent().build();
     }
@@ -109,7 +110,7 @@ public class UserResource extends AbstractResource {
     @Permissions(
             @Permission(value = RolePermission.ORGANIZATION_USERS, acls = RolePermissionAction.READ)
     )
-    public List<UserGroupEntity> getGroups(@PathParam("id") String userId) {
+    public List<UserGroupEntity> getUserGroups() {
         List<UserGroupEntity> groups = new ArrayList<>();
         groupService.findByUser(userId).forEach(groupEntity -> {
             UserGroupEntity userGroupEntity = new UserGroupEntity();
@@ -138,7 +139,7 @@ public class UserResource extends AbstractResource {
     @Permissions(
             @Permission(value = RolePermission.ORGANIZATION_USERS, acls = RolePermissionAction.READ)
     )
-    public UserMembershipList getMemberships(@PathParam("id") String userId, @QueryParam("type") String sType) {
+    public UserMembershipList getUserMemberships(@QueryParam("type") String sType) {
         MembershipReferenceType type = null;
         if (sType != null) {
             type = MembershipReferenceType.valueOf(sType.toUpperCase());
@@ -163,7 +164,7 @@ public class UserResource extends AbstractResource {
             // if permission changes or a new one is added, please update io.gravitee.rest.api.service.impl.UserServiceImpl#canResetPassword
     )
     @Path("resetPassword")
-    public Response resetPassword(@PathParam("id") String userId) {
+    public Response resetUserPassword() {
         userService.resetPassword(userId);
         return Response.noContent().build();
     }
@@ -175,13 +176,13 @@ public class UserResource extends AbstractResource {
             @ApiResponse(code = 200, message = "User's avatar"),
             @ApiResponse(code = 404, message = "User not found"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Response getUserAvatar(@PathParam("id") String id, @Context Request request) {
-        PictureEntity picture = userService.getPicture(id);
+    public Response getUserAvatar(@Context Request request) {
+        PictureEntity picture = userService.getPicture(userId);
 
         if (picture instanceof UrlPictureEntity) {
             return Response.temporaryRedirect(URI.create(((UrlPictureEntity) picture).getUrl())).build();
         }
-        
+
         InlinePictureEntity image = (InlinePictureEntity) picture;
         if (image == null || image.getContent() == null) {
             return Response.ok().build();
@@ -215,13 +216,13 @@ public class UserResource extends AbstractResource {
                 .type(image.getType())
                 .build();
     }
-    
+
     @PUT
     @Path("/roles")
     @Permissions(
             @Permission(value = RolePermission.ORGANIZATION_USERS, acls = RolePermissionAction.UPDATE)
     )
-    public Response updateUserRoles(@PathParam("id") String userId, List<String> roleIds ) {
+    public Response updateUserRoles(List<String> roleIds ) {
         userService.updateUserRoles(userId, roleIds);
         return Response.ok().build();
     }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/UsersRegistrationResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/UsersRegistrationResource.java
@@ -85,7 +85,7 @@ public class UsersRegistrationResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "User successfully created", response = UserEntity.class),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public Response finalizeRegistration(@Valid RegisterUserEntity registerUserEntity) {
+    public Response finalizeUserRegistration(@Valid RegisterUserEntity registerUserEntity) {
         UserEntity newUser = userService.finalizeRegistration(registerUserEntity);
         if (newUser != null) {
             return Response

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/UsersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/UsersResource.java
@@ -65,7 +65,7 @@ public class UsersResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List users matching the query criteria", response = UserEntity.class, responseContainer = "PagedResult"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public PagedResult<UserEntity> findAll(
+    public PagedResult<UserEntity> getAllUsers(
             @ApiParam(name = "q")
             @QueryParam("q") String query,
             @Valid @BeanParam Pageable pageable) {
@@ -94,7 +94,7 @@ public class UsersResource extends AbstractResource {
         return Response.serverError().build();
     }
 
-    @Path("{id}")
+    @Path("{userId}")
     public UserResource getUserResource() {
         return resourceContext.getResource(UserResource.class);
     }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/application/registration/ClientRegistrationProvidersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/application/registration/ClientRegistrationProvidersResource.java
@@ -16,18 +16,17 @@
 package io.gravitee.rest.api.management.rest.resource.configuration.application.registration;
 
 import io.gravitee.common.http.MediaType;
+import io.gravitee.rest.api.management.rest.model.configuration.application.ClientRegistrationProviderListItem;
+import io.gravitee.rest.api.management.rest.resource.AbstractResource;
+import io.gravitee.rest.api.management.rest.security.Permission;
+import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.model.configuration.application.registration.ClientRegistrationProviderEntity;
 import io.gravitee.rest.api.model.configuration.application.registration.InitialAccessTokenType;
 import io.gravitee.rest.api.model.configuration.application.registration.NewClientRegistrationProviderEntity;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
-import io.gravitee.rest.api.management.rest.model.configuration.application.ClientRegistrationProviderListItem;
-import io.gravitee.rest.api.management.rest.resource.AbstractResource;
-import io.gravitee.rest.api.management.rest.security.Permission;
-import io.gravitee.rest.api.management.rest.security.Permissions;
 import io.gravitee.rest.api.service.configuration.application.ClientRegistrationService;
 import io.swagger.annotations.*;
-
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.validation.Valid;
@@ -63,7 +62,7 @@ public class ClientRegistrationProvidersResource extends AbstractResource {
             @ApiResponse(code = 200, message = "List client registration providers",
                     response = ClientRegistrationProviderListItem.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<ClientRegistrationProviderListItem> listClientRegistrationProviders() {
+    public List<ClientRegistrationProviderListItem> getClientRegistrationProviders() {
         return clientRegistrationService.findAll().stream().map(clientRegistrationProvider -> {
             ClientRegistrationProviderListItem item = new ClientRegistrationProviderListItem();
             item.setId(clientRegistrationProvider.getId());

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/dictionary/DictionariesResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/dictionary/DictionariesResource.java
@@ -16,17 +16,16 @@
 package io.gravitee.rest.api.management.rest.resource.configuration.dictionary;
 
 import io.gravitee.common.http.MediaType;
-import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
-import io.gravitee.rest.api.model.configuration.dictionary.NewDictionaryEntity;
-import io.gravitee.rest.api.model.permissions.RolePermission;
-import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.management.rest.model.configuration.dictionary.DictionaryListItem;
 import io.gravitee.rest.api.management.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
+import io.gravitee.rest.api.model.configuration.dictionary.DictionaryEntity;
+import io.gravitee.rest.api.model.configuration.dictionary.NewDictionaryEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.configuration.dictionary.DictionaryService;
 import io.swagger.annotations.*;
-
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.validation.Valid;
@@ -61,7 +60,7 @@ public class DictionariesResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List global dictionaries", response = DictionaryListItem.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<DictionaryListItem> listDictionaries()  {
+    public List<DictionaryListItem> getDictionaries()  {
         return dictionaryService
                 .findAll()
                 .stream()

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/identity/IdentityProvidersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/configuration/identity/IdentityProvidersResource.java
@@ -16,17 +16,16 @@
 package io.gravitee.rest.api.management.rest.resource.configuration.identity;
 
 import io.gravitee.common.http.MediaType;
-import io.gravitee.rest.api.model.configuration.identity.IdentityProviderEntity;
-import io.gravitee.rest.api.model.configuration.identity.NewIdentityProviderEntity;
-import io.gravitee.rest.api.model.permissions.RolePermission;
-import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.management.rest.model.configuration.identity.IdentityProviderListItem;
 import io.gravitee.rest.api.management.rest.resource.AbstractResource;
 import io.gravitee.rest.api.management.rest.security.Permission;
 import io.gravitee.rest.api.management.rest.security.Permissions;
+import io.gravitee.rest.api.model.configuration.identity.IdentityProviderEntity;
+import io.gravitee.rest.api.model.configuration.identity.NewIdentityProviderEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.configuration.identity.IdentityProviderService;
 import io.swagger.annotations.*;
-
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.validation.Valid;
@@ -61,7 +60,7 @@ public class IdentityProvidersResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List identity providers", response = IdentityProviderListItem.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<IdentityProviderListItem> listIdentityProviders() {
+    public List<IdentityProviderListItem> getIdentityProviders() {
         return identityProviderService.findAll().stream().map(identityProvider -> {
             IdentityProviderListItem item = new IdentityProviderListItem();
             item.setId(identityProvider.getId());

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/portal/SocialIdentityProvidersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/portal/SocialIdentityProvidersResource.java
@@ -16,14 +16,13 @@
 package io.gravitee.rest.api.management.rest.resource.portal;
 
 import io.gravitee.common.http.MediaType;
-import io.gravitee.rest.api.model.configuration.identity.SocialIdentityProviderEntity;
 import io.gravitee.rest.api.management.rest.resource.AbstractResource;
+import io.gravitee.rest.api.model.configuration.identity.SocialIdentityProviderEntity;
 import io.gravitee.rest.api.service.SocialIdentityProviderService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.ws.rs.Consumes;
@@ -51,7 +50,7 @@ public class SocialIdentityProvidersResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List social identity providers", response = SocialIdentityProviderEntity.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<SocialIdentityProviderEntity> listSocialIdentityProvider() {
+    public List<SocialIdentityProviderEntity> getSocialIdentityProvider() {
         return socialIdentityProviderService.findAll()
                 .stream()
                 .sorted((idp1, idp2) -> String.CASE_INSENSITIVE_ORDER.compare(idp1.getName(), idp2.getName()))

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/quality/QualityRuleResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/quality/QualityRuleResource.java
@@ -24,12 +24,9 @@ import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.quality.QualityRuleEntity;
 import io.gravitee.rest.api.model.quality.UpdateQualityRuleEntity;
 import io.gravitee.rest.api.service.QualityRuleService;
-import io.swagger.annotations.Api;
-import io.swagger.annotations.ApiOperation;
-import io.swagger.annotations.ApiResponse;
-import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
+import io.swagger.annotations.*;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -43,8 +40,12 @@ import static io.gravitee.common.http.MediaType.APPLICATION_JSON;
 @Api(tags = {"Configuration"})
 public class QualityRuleResource extends AbstractResource {
 
-    @Autowired
+    @Inject
     private QualityRuleService qualityRuleService;
+
+    @PathParam("id")
+    @ApiParam(name = "id", required = true)
+    private String id;
 
     @GET
     @Produces(APPLICATION_JSON)
@@ -57,7 +58,7 @@ public class QualityRuleResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_QUALITY_RULE, acls = RolePermissionAction.READ)
     })
-    public QualityRuleEntity get(@PathParam("id") String id) {
+    public QualityRuleEntity getQualityRule() {
         return qualityRuleService.findById(id);
     }
 
@@ -74,7 +75,7 @@ public class QualityRuleResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_QUALITY_RULE, acls = RolePermissionAction.UPDATE)
     })
-    public QualityRuleEntity update(@PathParam("id") String id, @Valid @NotNull final UpdateQualityRuleEntity updateQualityRuleEntity) {
+    public QualityRuleEntity updateQualityRule(@Valid @NotNull final UpdateQualityRuleEntity updateQualityRuleEntity) {
         updateQualityRuleEntity.setId(id);
         return qualityRuleService.update(updateQualityRuleEntity);
     }
@@ -90,7 +91,7 @@ public class QualityRuleResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_QUALITY_RULE, acls = RolePermissionAction.DELETE)
     })
-    public void delete(@PathParam("id") String id) {
+    public void deleteQualityRule() {
         qualityRuleService.delete(id);
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/quality/QualityRulesResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/quality/QualityRulesResource.java
@@ -29,8 +29,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.inject.Inject;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
@@ -49,7 +49,8 @@ public class QualityRulesResource extends AbstractResource {
 
     @Context
     private ResourceContext resourceContext;
-    @Autowired
+
+    @Inject
     private QualityRuleService qualityRuleService;
 
     @GET
@@ -58,7 +59,7 @@ public class QualityRulesResource extends AbstractResource {
     @ApiResponses({
             @ApiResponse(code = 200, message = "List of quality rules", response = QualityRuleEntity.class, responseContainer = "List"),
             @ApiResponse(code = 500, message = "Internal server error")})
-    public List<QualityRuleEntity> get() {
+    public List<QualityRuleEntity> getQualityRules() {
         if (!hasPermission(RolePermission.ENVIRONMENT_QUALITY_RULE, RolePermissionAction.READ) &&
                 !canReadAPIConfiguration()) {
             throw new ForbiddenAccessException();
@@ -77,7 +78,7 @@ public class QualityRulesResource extends AbstractResource {
     @Permissions({
             @Permission(value = RolePermission.ENVIRONMENT_QUALITY_RULE, acls = RolePermissionAction.CREATE)
     })
-    public QualityRuleEntity create(@Valid @NotNull final NewQualityRuleEntity newQualityRuleEntity) {
+    public QualityRuleEntity createQualityRule(@Valid @NotNull final NewQualityRuleEntity newQualityRuleEntity) {
         return qualityRuleService.create(newQualityRuleEntity);
     }
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/swagger/GraviteeApiDefinition.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/swagger/GraviteeApiDefinition.java
@@ -19,7 +19,11 @@ import io.swagger.annotations.SwaggerDefinition;
 import io.swagger.jaxrs.Reader;
 import io.swagger.jaxrs.config.ReaderListener;
 import io.swagger.models.Swagger;
+import io.swagger.models.Tag;
 import io.swagger.models.auth.BasicAuthDefinition;
+
+import java.util.Comparator;
+import java.util.TreeMap;
 
 /**
  * @author David BRASSELY (david.brassely at graviteesource.com)
@@ -36,14 +40,16 @@ public class GraviteeApiDefinition implements ReaderListener {
 
     @Override
     public void afterScan(Reader reader, Swagger swagger) {
+        // sort tags for better comparisons
+        swagger.getTags().sort(Comparator.comparing(Tag::getName));
+        // sort paths for better comparisons
+        swagger.setPaths(new TreeMap<>(swagger.getPaths()));
+        // sort definitions for better comparisons
+        swagger.setDefinitions(new TreeMap<>(swagger.getDefinitions()));
         swagger.addSecurityDefinition(TOKEN_AUTH_SCHEME, new BasicAuthDefinition());
 
         swagger.getPaths().values()
-                .stream()
-                .forEach(
-                        path -> path.getOperations()
-                                .stream()
-                                .forEach(
-                                        operation -> operation.addSecurity(GraviteeApiDefinition.TOKEN_AUTH_SCHEME, null)));
+                .forEach(path -> path.getOperations()
+                        .forEach(operation -> operation.addSecurity(GraviteeApiDefinition.TOKEN_AUTH_SCHEME, null)));
     }
 }


### PR DESCRIPTION
Invalid swagger definition is fixed by:

* removing the @Path from NotifiersResource
* adding the missing path params for `orgId` and `envId`
* removing the duplicated class MembershipListItem from RoleUsersResource.java, which had the missing property `role`

Additionally:
* the tags, paths and definition within the swagger definition are now sorted, so it can be diffed easier
* since the operationIds were not unique, the method-names were renamed to be as unique as possible (not all duplicates could be avoided)

resolves gravitee-io/issues#4394