### PR TITLE
fix(management): fix for API import

### DIFF
--- a/gravitee-rest-api-service/pom.xml
+++ b/gravitee-rest-api-service/pom.xml
@@ -193,6 +193,12 @@
 			<groupId>io.swagger.parser.v3</groupId>
 			<artifactId>swagger-parser</artifactId>
 			<version>${swagger-parser.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.github.fge</groupId>
+					<artifactId>json-patch</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -194,9 +194,6 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
     @Override
     public ApiEntity createFromSwagger(final SwaggerApiEntity swaggerApiEntity, final String userId,
                                        final ImportSwaggerDescriptorEntity swaggerDescriptor) throws ApiAlreadyExistsException {
-        checkGroupExistence(swaggerApiEntity.getGroups());
-
-        checkShardingTags(swaggerApiEntity, null);
 
         if (swaggerApiEntity != null && swaggerDescriptor != null) {
 

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -2213,7 +2213,7 @@ public class PageServiceImpl extends TransactionalService implements PageService
         try {
             final NewPageEntity newPage = convertToEntity(pageDefinition);
             JsonNode jsonNode = objectMapper.readTree(pageDefinition);
-            return createPage(apiId, newPage, GraviteeContext.getCurrentEnvironment(), jsonNode.get("id").asText());
+            return createPage(apiId, newPage, GraviteeContext.getCurrentEnvironment(), (jsonNode.get("id") != null ? jsonNode.get("id").asText() : null));
         } catch (JsonProcessingException e) {
             logger.error("An error occurs while trying to JSON deserialize the Page {}", pageDefinition, e);
             throw new TechnicalManagementException("An error occurs while trying to JSON deserialize the Page definition.");

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SwaggerServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SwaggerServiceImpl.java
@@ -21,6 +21,7 @@ import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity.Format;
 import io.gravitee.rest.api.model.api.SwaggerApiEntity;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.SwaggerService;
+import io.gravitee.rest.api.service.TagService;
 import io.gravitee.rest.api.service.exceptions.SwaggerDescriptorException;
 import io.gravitee.rest.api.service.impl.swagger.converter.api.OAIToAPIConverter;
 import io.gravitee.rest.api.service.impl.swagger.parser.OAIParser;
@@ -68,6 +69,9 @@ public class SwaggerServiceImpl implements SwaggerService {
     @Autowired
     private GroupService groupService;
 
+    @Autowired
+    private TagService tagService;
+
     @Override
     public SwaggerApiEntity createAPI(ImportSwaggerDescriptorEntity swaggerDescriptor) {
         boolean wsdlImport = Format.WSDL.equals(swaggerDescriptor.getFormat());
@@ -86,7 +90,7 @@ public class SwaggerServiceImpl implements SwaggerService {
                         .map(operationVisitor -> policyOperationVisitorManager.getOAIOperationVisitor(operationVisitor.getId()))
                         .collect(Collectors.toList());
             }
-            return new OAIToAPIConverter(visitors, groupService)
+            return new OAIToAPIConverter(visitors, groupService, tagService)
                     .convert((OAIDescriptor) descriptor);
 
         }

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPITest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/SwaggerService_CreateAPITest.java
@@ -23,10 +23,7 @@ import io.gravitee.definition.model.Path;
 import io.gravitee.definition.model.Rule;
 import io.gravitee.definition.model.VirtualHost;
 import io.gravitee.policy.api.swagger.Policy;
-import io.gravitee.rest.api.model.ApiMetadataEntity;
-import io.gravitee.rest.api.model.GroupEntity;
-import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
-import io.gravitee.rest.api.model.Visibility;
+import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.SwaggerApiEntity;
 import io.gravitee.rest.api.model.api.UpdateApiEntity;
 import io.gravitee.rest.api.service.impl.SwaggerServiceImpl;
@@ -67,6 +64,9 @@ public class SwaggerService_CreateAPITest {
     @Mock
     private GroupService groupService;
 
+    @Mock
+    private TagService tagService;
+
     @InjectMocks
     private SwaggerServiceImpl swaggerService;
 
@@ -91,6 +91,14 @@ public class SwaggerService_CreateAPITest {
         grp2.setId("group2");
         when(groupService.findByName("group1")).thenReturn(Arrays.asList(grp1));
         when(groupService.findByName("group2")).thenReturn(Arrays.asList(grp2));
+
+        TagEntity tag1 = new TagEntity();
+        tag1.setId("tagId1");
+        tag1.setName("tag1");
+        TagEntity tag2 = new TagEntity();
+        tag2.setId("tagId2");
+        tag2.setName("tag2");
+        when(tagService.findAll()).thenReturn(Arrays.asList(tag1, tag2));
     }
 
     // Swagger v1
@@ -196,7 +204,7 @@ public class SwaggerService_CreateAPITest {
 
         final Set<String> tags = updateApiEntity.getTags();
         assertEquals(2, tags.size());
-        assertTrue(tags.containsAll(asList("tag1", "tag2")));
+        assertTrue(tags.containsAll(asList("tagId1", "tagId2")));
         
         final Map<String, String> properties = updateApiEntity.getProperties().getValues();
         assertEquals(2, properties.size());


### PR DESCRIPTION
* fixes pages creation when no pageId defined
* do not fail when non existing tags are imported. Filter them instead
* exclude old version of json-patch to prevent conflicts

Fixes gravitee-io/issues#4439