### PR TITLE
fix(api): do not send categories with no APIs available for user

### DIFF
--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResource.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResource.java
@@ -68,6 +68,7 @@ public class CategoriesResource extends AbstractResource {
                     c.setTotalApis(categoryService.getTotalApisByCategory(apis, c));
                     return c;
                 })
+                .filter(c -> c.getTotalApis() > 0)
                 .map(c-> categoryMapper.convert(c, uriInfo.getBaseUriBuilder()))
                 .collect(Collectors.toList());
         

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResourceNotAuthenticatedTest.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/CategoriesResourceNotAuthenticatedTest.java
@@ -103,6 +103,7 @@ public class CategoriesResourceNotAuthenticatedTest extends AbstractResourceTest
         
         List<CategoryEntity> mockCategories = Arrays.asList(category1, category2, category3);
         doReturn(mockCategories).when(categoryService).findAll();
+        doReturn(1L).when(categoryService).getTotalApisByCategory(any(), any()) ;
 
         doReturn(false).when(ratingService).isEnabled();
 


### PR DESCRIPTION
fixes gravitee-io/issues#4477