### PR TITLE
fix: Example cURL not displayed for an unpublished API on subscriptions

### DIFF
--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
@@ -119,11 +119,10 @@ public class ApiResource extends AbstractResource {
     @Produces({ MediaType.WILDCARD, MediaType.APPLICATION_JSON })
     @RequirePortalAuth
     public Response getPictureByApiId(@Context Request request, @PathParam("apiId") String apiId) {
-        Collection<ApiEntity> userApis = apiService.findPublishedByUser(getAuthenticatedUserOrNull());
+        // Do not filter on visibility to display the picture on subscription screen even if the API is no more published
+        Collection<ApiEntity> userApis = apiService.findByUser(getAuthenticatedUserOrNull(), null, true);
         if (userApis.stream().anyMatch(a -> a.getId().equals(apiId))) {
-
             InlinePictureEntity image = apiService.getPicture(apiId);
-
             return createPictureResponse(request, image);
         }
         throw new ApiNotFoundException(apiId);

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/SubscriptionsResource.java
@@ -161,6 +161,7 @@ public class SubscriptionsResource extends AbstractResource {
                 m.put("pictureUrl", apiMapper
                         .computeApiLinks(PortalApiLinkHelper.apisURL(uriInfo.getBaseUriBuilder(), api.getId()), api.getUpdatedAt()).getPicture());
                 m.put("version", api.getVersion());
+                m.put("entrypoints", api.getEntrypoints());
                 metadata.put(api.getId(), m);
             }
             final PlanEntity plan = planService.findById(subscription.getPlan());

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceTest.java
@@ -40,8 +40,7 @@ import java.util.*;
 import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -68,6 +67,7 @@ public class ApiResourceTest extends AbstractResourceTest {
 
         Set<ApiEntity> mockApis = new HashSet<>(Arrays.asList(mockApi));
         doReturn(mockApis).when(apiService).findPublishedByUser(any());
+        doReturn(mockApis).when(apiService).findByUser(any(), any(), eq(true));
 
         Api api = new Api();
         api.setId(API);
@@ -193,7 +193,7 @@ public class ApiResourceTest extends AbstractResourceTest {
         ApiEntity userApi = new ApiEntity();
         userApi.setId("1");
         Set<ApiEntity> mockApis = new HashSet<>(Arrays.asList(userApi));
-        doReturn(mockApis).when(apiService).findPublishedByUser(any());
+        doReturn(mockApis).when(apiService).findByUser(any(), any(), eq(true));
 
         // test
         final Response response = target(API).path("picture").request().get();


### PR DESCRIPTION
fix gravitee-io/issues#4680