### PR TITLE
fix(management): revoke all apikey when closing a subscription

### DIFF
--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -529,7 +529,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
                     List<ApiKeyEntity> apiKeys = apiKeyService.findBySubscription(subscription.getId());
                     for (ApiKeyEntity apiKey : apiKeys) {
                         Date expireAt = apiKey.getExpireAt();
-                        if (!apiKey.isRevoked() && (expireAt == null || expireAt.equals(now) || expireAt.before(now))) {
+                        if (!apiKey.isRevoked()) {
                             apiKey.setExpireAt(now);
                             apiKey.setRevokedAt(now);
                             apiKey.setRevoked(true);


### PR DESCRIPTION
Fixes gravitee-io/issues#4799