### PR TITLE
fix(management): an apikey should not be reactivated on closed plans

### DIFF
--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/SubscriptionNotActiveException.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/SubscriptionNotActiveException.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class SubscriptionNotActiveException extends AbstractManagementException {
+
+    private final SubscriptionEntity subscription;
+
+    public SubscriptionNotActiveException(SubscriptionEntity subscription) {
+        this.subscription = subscription;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Subscription [" + subscription.getId() + "] should be paused or accepted. Currently it is " + subscription.getStatus();
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "subscription.closed";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return new HashMap<String, String>() {
+            {
+                put("subscription", subscription.getId());
+                put("status", subscription.getStatus().name());
+            }
+        };
+    }
+}

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiKeyServiceImpl.java
@@ -264,13 +264,16 @@ public class ApiKeyServiceImpl extends TransactionalService implements ApiKeySer
                 throw new ApiKeyAlreadyActivatedException("The API key is already activated");
             }
 
+            // Get the subscription to get ending date and set key expiration date.
+            SubscriptionEntity subscription = subscriptionService.findById(key.getSubscription());
+            if (subscription.getStatus() != SubscriptionStatus.PAUSED && subscription.getStatus() != SubscriptionStatus.ACCEPTED) {
+                throw new SubscriptionNotActiveException(subscription);
+            }
+
             ApiKey previousApiKey = new ApiKey(key);
             key.setRevoked(false);
             key.setUpdatedAt(new Date());
             key.setRevokedAt(null);
-
-            // Get the subscription to get ending date and set key expiration date.
-            SubscriptionEntity subscription = subscriptionService.findById(key.getSubscription());
             key.setExpireAt(subscription.getEndingAt());
 
             ApiKey updated = apiKeyRepository.update(key);


### PR DESCRIPTION
Fixes gravitee-io/issues#4846