### PR TITLE
feat: add API and UI URLs in HelloCommandSend to Cockpit

### DIFF
--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/commands/HelloCommandProducer.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/commands/HelloCommandProducer.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.model.InstallationEntity;
 import io.gravitee.rest.api.service.InstallationService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.reactivex.Single;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -36,6 +37,15 @@ import java.util.Map;
  */
 @Component("cockpitHelloCommandProducer")
 public class HelloCommandProducer implements CommandProducer<HelloCommand, HelloReply> {
+
+    private static final String UI_URL = "UI_URL";
+    private static final String API_URL = "API_URL";
+
+    @Value("${console.ui.url:http://localhost:3000}")
+    private String uiURL;
+
+    @Value("${console.api.url:http://localhost:8083/management}")
+    private String apiURL;
 
     private final Node node;
     private final InstallationService installationService;
@@ -58,6 +68,8 @@ public class HelloCommandProducer implements CommandProducer<HelloCommand, Hello
         command.getPayload().getNode().setInstallationId(installation.getId());
         command.getPayload().getNode().setHostname(node.hostname());
         command.getPayload().getAdditionalInformation().putAll(installation.getAdditionalInformation());
+        command.getPayload().getAdditionalInformation().put(UI_URL, uiURL);
+        command.getPayload().getAdditionalInformation().put(API_URL, apiURL);
         command.getPayload().setDefaultOrganizationId(GraviteeContext.getDefaultOrganization());
         command.getPayload().setDefaultEnvironmentId(GraviteeContext.getDefaultEnvironment());
 

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/commands/HelloCommandProducerTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/commands/HelloCommandProducerTest.java
@@ -31,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 /**
@@ -80,6 +81,9 @@ public class HelloCommandProducerTest {
         obs.awaitTerminalEvent();
         obs.assertValue(helloCommand -> {
             assertEquals(CUSTOM_VALUE, helloCommand.getPayload().getAdditionalInformation().get(CUSTOM_KEY));
+            assertTrue(helloCommand.getPayload().getAdditionalInformation().containsKey("UI_URL"));
+            assertTrue(helloCommand.getPayload().getAdditionalInformation().containsKey("API_URL"));
+
             assertEquals(HOSTNAME, helloCommand.getPayload().getNode().getHostname());
             assertEquals(GraviteeContext.getDefaultOrganization(), helloCommand.getPayload().getDefaultOrganizationId());
             assertEquals(GraviteeContext.getDefaultEnvironment(), helloCommand.getPayload().getDefaultEnvironmentId());

--- a/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -11,6 +11,13 @@
 # Please have a look to http://docs.gravitee.io/ for more options and fine-grained granularity
 ############################################################################################################
 
+# Specify the URL of the Management API and UI of this instance, mandatory if you want to connect it to Cockpit
+#console:
+#  ui:
+#    url: http://localhost:3000
+#  api:
+#    url: http://localhost:8083/management
+
 # HTTP Server
 #jetty:
 #  IP/hostname to bind to. Default is 0.0.0.0


### PR DESCRIPTION
**Issue**

Closes https://github.com/gravitee-io/issues/issues/4981

**Description**

Add `API_URL` and `UI_URL` in the `additionalInformation` sent to cockpit in the HelloCommand.
The default values are the ones to make everything work locally.