### PR TITLE
fix(page): Do not allow injection in Markdown links

### DIFF
--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizer.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizer.java
@@ -33,7 +33,7 @@ import java.util.List;
 public final class HtmlSanitizer {
 
     private static final Parser mdParser = Parser.builder(new MutableDataSet()).build();
-    private static final HtmlRenderer htmlRenderer = HtmlRenderer.builder(new MutableDataSet()).build();
+    private static final HtmlRenderer htmlRenderer = HtmlRenderer.builder(new MutableDataSet().set(HtmlRenderer.SUPPRESSED_LINKS, "")).build();
 
     private static final AttributePolicy INTEGER = new AttributePolicy() {
         @Override
@@ -72,7 +72,8 @@ public final class HtmlSanitizer {
             .and(Sanitizers.FORMATTING)
             .and(new HtmlPolicyBuilder()
                     .allowStandardUrlProtocols().allowElements("a")
-                    .allowAttributes("href").onElements("a")
+                    .allowAttributes("href", "title")
+                    .onElements("a")
                     .toFactory())
             .and(HTML_CSS_SANITIZER)
             .and(Sanitizers.TABLES)

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizerTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/HtmlSanitizerTest.java
@@ -100,6 +100,15 @@ public class HtmlSanitizerTest {
         return html;
     }
 
+    @Test
+    public void isNotSafe_markdownLink() {
+        final String content = "[my_link](javascript:alert('xss'))";
+        HtmlSanitizer.SanitizeInfos sanitizeInfos = HtmlSanitizer.isSafe(content);
+
+        assertFalse(sanitizeInfos.isSafe());
+        assertEquals("[Tag not allowed: a]", sanitizeInfos.getRejectedMessage());
+    }
+
     private String getNotSafe() {
 
         String html = "";


### PR DESCRIPTION
Closes gravitee-io/issues#5031