### PR TITLE
feat(management): Manage API PO in a group

### DIFF
--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.NotifierService;
@@ -198,7 +199,11 @@ public class GroupMembersResource extends AbstractResource {
                                 updatedMembership.getId(),
                                 previousApiRole.getId());
                     }
-
+                    if (previousApiRole != null && previousApiRole.getName().equals(SystemRole.PRIMARY_OWNER.name())) {
+                        groupService.updateApiPrimaryOwner(group, null);
+                    } else if(roleName.equals(SystemRole.PRIMARY_OWNER.name())) {
+                        groupService.updateApiPrimaryOwner(group, updatedMembership.getId());
+                    }
                 }
                 
                 RoleEntity applicationRoleEntity = roleEntities.get(RoleScope.APPLICATION);

--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/GroupEntity.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/GroupEntity.java
@@ -16,7 +16,6 @@
 package io.gravitee.rest.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.gravitee.rest.api.model.permissions.RoleScope;
 
 import java.util.Date;
@@ -52,6 +51,7 @@ public class GroupEntity {
     private boolean emailInvitation;
     @JsonProperty("disable_membership_notifications")
     private boolean disableMembershipNotifications;
+    private String apiPrimaryOwner;
 
     public String getId() {
         return id;
@@ -157,6 +157,14 @@ public class GroupEntity {
         this.disableMembershipNotifications = disableMembershipNotifications;
     }
 
+    public String getApiPrimaryOwner() {
+        return apiPrimaryOwner;
+    }
+
+    public void setApiPrimaryOwner(String apiPrimaryOwner) {
+        this.apiPrimaryOwner = apiPrimaryOwner;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -186,6 +194,7 @@ public class GroupEntity {
                 ", systemInvitation=" + systemInvitation +
                 ", emailInvitation=" + emailInvitation +
                 ", disableMembershipNotifications=" + disableMembershipNotifications +
+                ", apiPrimaryOwner=" + apiPrimaryOwner +
                 '}';
     }
 }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
@@ -16,7 +16,10 @@
 package io.gravitee.rest.api.service;
 
 import io.gravitee.repository.management.model.GroupEvent;
-import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.ApplicationEntity;
+import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.NewGroupEntity;
+import io.gravitee.rest.api.model.UpdateGroupEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 
 import java.util.List;
@@ -28,8 +31,6 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface GroupService {
-
-    void                    addUserToGroup                      (String groupId, String username, String... roleIds);
     GroupEntity             create                              (NewGroupEntity group);
     void                    delete                              (String groupId);
     void                    deleteUserFromGroup                 (String groupId, String username);
@@ -46,4 +47,5 @@ public interface GroupService {
     boolean                 isUserAuthorizedToAccessApiData     (ApiEntity api, List<String> excludedGroups, String username);
     boolean                 isUserAuthorizedToAccessPortalData  (List<String> excludedGroups, String username);
     GroupEntity             update                              (String groupId, UpdateGroupEntity group);
+    void                    updateApiPrimaryOwner               (String groupId, String newApiPrimaryOwner);
 }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -82,7 +82,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
     private PlanRepository planRepository;
     @Autowired
     private IdentityProviderRepository identityProviderRepository;
-    
+
     @Override
     public List<GroupEntity> findAll() {
         try {
@@ -185,8 +185,8 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             GroupEntity grp = this.map(groupRepository.update(updatedGroup));
             logger.debug("update {} - DONE", grp);
 
-            updateDefautRoles(groupId, updatedGroupEntity.getRoles(), group.getRoles());
-            
+            updateDefaultRoles(groupId, updatedGroupEntity.getRoles(), group.getRoles());
+
             // Audit
             auditService.createEnvironmentAuditLog(
                     Collections.singletonMap(GROUP, groupId),
@@ -202,19 +202,28 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         }
     }
 
-    private void updateDefautRoles(String groupId, Map<RoleScope, String> formerRoles, Map<RoleScope, String> newRoles) throws TechnicalException {
+    private void updateDefaultRoles(String groupId, Map<RoleScope, String> formerRoles, Map<RoleScope, String> newRoles) throws TechnicalException {
         RoleScope[] groupRoleScopes = { RoleScope.API, RoleScope.APPLICATION };
-        for(RoleScope roleScope: groupRoleScopes) {
+        for (RoleScope roleScope : groupRoleScopes) {
             if (
-                    (formerRoles != null && formerRoles.get(roleScope) != null) 
-                    && (newRoles == null || (newRoles != null && !formerRoles.get(roleScope).equals(newRoles.get(roleScope))))
-                    ) {
+                    formerRoles != null &&
+                            formerRoles.get(roleScope) != null &&
+                            (newRoles == null ||
+                                    (newRoles != null &&
+                                            !formerRoles.get(roleScope).equals(newRoles.get(roleScope)) &&
+                                            !SystemRole.PRIMARY_OWNER.name().equals(newRoles.get(roleScope))))
+            ) {
                 removeOldDefaultRole(groupId, MembershipReferenceType.valueOf(roleScope.name()));
             }
+
             if (
-                    (newRoles != null && newRoles.get(roleScope) != null) 
-                    && (formerRoles == null || (formerRoles != null && !newRoles.get(roleScope).equals(formerRoles.get(roleScope))))
-                    ) {
+                    newRoles != null &&
+                            newRoles.get(roleScope) != null  &&
+                            !SystemRole.PRIMARY_OWNER.name().equals(newRoles.get(roleScope)) &&
+                            (formerRoles == null ||
+                                    (formerRoles != null &&
+                                            !newRoles.get(roleScope).equals(formerRoles.get(roleScope))))
+            ) {
                 addNewDefaultRole(groupId, newRoles.get(roleScope), roleScope);
             }
         }
@@ -231,7 +240,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                 new MembershipService.MembershipRole(roleScope, newRole));
 
     }
-    
+
     @Override
     public GroupEntity findById(String groupId) {
         try {
@@ -372,7 +381,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
             }
             //remove all members
             membershipService.deleteReference(MembershipReferenceType.GROUP, groupId);
-            
+
             //remove all applications or apis
             Date updatedDate = new Date();
             apiRepository.search(new ApiCriteria.Builder().environmentId(GraviteeContext.getCurrentEnvironment()).groups(groupId).build()).forEach(api -> {
@@ -506,17 +515,17 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         }
 
         // in connected mode,
-        
+
         // if no restriction defined
         if (excludedGroups == null || excludedGroups.isEmpty()) {
             return true;
         }
-        
+
         // if user is a direct member of the API
         if (!membershipService.getRoles(MembershipReferenceType.API, api.getId(), MembershipMemberType.USER, username).isEmpty()) {
             return true;
         }
-        
+
         // for public apis
         // user must not be a member of any exclusion group.
         // That is user must not have no API role on each of the exclusion groups
@@ -527,7 +536,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                             .noneMatch(role -> role.getScope() == RoleScope.API)
                     );
         }
-        
+
         // for private apis
         // user must be in at least one attached group which is not also an exclusion group.
         if (Visibility.PRIVATE.equals(api.getVisibility()) && api.getGroups() != null && !api.getGroups().isEmpty()) {
@@ -554,7 +563,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         }
 
         // in connected mode
-        
+
         // if no restriction defined
         if (excludedGroups == null || excludedGroups.isEmpty()) {
             return true;
@@ -684,6 +693,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         GroupEntity entity = new GroupEntity();
         entity.setId(group.getId());
         entity.setName(group.getName());
+        entity.setApiPrimaryOwner(group.getApiPrimaryOwner());
 
         if(group.getEventRules() != null && !group.getEventRules().isEmpty()) {
             List<GroupEventRuleEntity> groupEventRules = new ArrayList<>();
@@ -723,15 +733,10 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
         //check if user exist
         this.userService.findById(username);
         membershipService.deleteReferenceMember(MembershipReferenceType.GROUP, groupId, MembershipMemberType.USER, username);
-    }
 
-    @Override
-    public void addUserToGroup(String groupId, String username, String... roleIds) {
-        //check if user exist
-        this.userService.findById(username);
-        
-        for(String roleId: roleIds) {
-            membershipService.addRoleToMemberOnReference(MembershipReferenceType.GROUP, groupId, MembershipMemberType.USER, username, roleId);
+        GroupEntity existingGroup = this.findById(groupId);
+        if(existingGroup.getApiPrimaryOwner() != null && existingGroup.getApiPrimaryOwner().equals(username)) {
+            updateApiPrimaryOwner(groupId, username);
         }
     }
 
@@ -745,7 +750,24 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
 
     @Override
     public int getNumberOfMembers(String groupId) {
-        return membershipService.getMembersByReference(MembershipReferenceType.GROUP, groupId).size() + 
+        return membershipService.getMembersByReference(MembershipReferenceType.GROUP, groupId).size() +
                 invitationService.findByReference(InvitationReferenceType.GROUP, groupId).size();
     }
+
+    @Override
+    public void updateApiPrimaryOwner(String groupId, String newApiPrimaryOwner) {
+        try {
+            Optional<Group> group = groupRepository.findById(groupId);
+            if (!group.isPresent()) {
+                throw new GroupNotFoundException(groupId);
+            }
+            final Group foundGroup = group.get();
+            foundGroup.setApiPrimaryOwner(newApiPrimaryOwner);
+            groupRepository.update(foundGroup);
+        } catch (TechnicalException ex) {
+            logger.error("An error occurs while trying to find or update a group", ex);
+            throw new TechnicalManagementException("An error occurs while trying to find or update a group", ex);
+        }
+    }
+
 }

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_UpdateTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_UpdateTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service;
+
+import io.gravitee.common.util.Maps;
+import io.gravitee.repository.management.api.GroupRepository;
+import io.gravitee.repository.management.model.Group;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.UpdateGroupEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.impl.GroupServiceImpl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class GroupService_UpdateTest {
+
+    private static final String GROUP_ID = "my-group-id";
+
+    @InjectMocks
+    private final GroupService groupService = new GroupServiceImpl();
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private MembershipService membershipService;
+
+    @Mock
+    private PermissionService permissionService;
+
+    @Mock
+    private AuditService auditService;
+
+    @Test
+    public void shouldUpdateGroup() throws Exception {
+
+        UpdateGroupEntity updatedGroupEntity = new UpdateGroupEntity();
+        updatedGroupEntity.setDisableMembershipNotifications(true);
+        updatedGroupEntity.setEmailInvitation(true);
+        updatedGroupEntity.setEventRules(null);
+        updatedGroupEntity.setLockApiRole(true);
+        updatedGroupEntity.setLockApplicationRole(true);
+        updatedGroupEntity.setMaxInvitation(100);
+        updatedGroupEntity.setName("my-group-name");
+        updatedGroupEntity.setRoles(Maps.<RoleScope, String>builder().put(RoleScope.API, "OWNER").build());
+        updatedGroupEntity.setSystemInvitation(false);
+
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(Mockito.mock(Group.class)));
+        when(permissionService.hasPermission(RolePermission.ENVIRONMENT_GROUP, "DEFAULT", CREATE, UPDATE, DELETE)).thenReturn(true);
+        when(membershipService.getRoles(any(),  any(),  any(),  any())).thenReturn(Collections.emptySet());
+
+        groupService.update(GROUP_ID, updatedGroupEntity);
+
+        verify(groupRepository).update(
+                argThat(
+                        group -> group.isDisableMembershipNotifications() &&
+                                group.isEmailInvitation() &&
+                                group.getEventRules() == null &&
+                                group.isLockApiRole() &&
+                                group.isLockApplicationRole() &&
+                                group.getMaxInvitation() == 100 &&
+                                group.getName().equals("my-group-name") &&
+                                !group.isSystemInvitation()
+                )
+        );
+
+        verify(membershipService).addRoleToMemberOnReference(
+                argThat(membershipReference -> membershipReference.getType() == MembershipReferenceType.API && membershipReference.getId() == null),
+                argThat(membershipMember -> membershipMember.getMemberId().equals(GROUP_ID) && membershipMember.getReference() == null && membershipMember.getMemberType() == MembershipMemberType.GROUP),
+                argThat(membershipRole -> membershipRole.getScope() == RoleScope.API && membershipRole.getName().equals("OWNER"))
+        );
+    }
+
+    @Test
+    public void shouldNotUpdateDefaultRoleBecausePrimaryOwner() throws Exception {
+
+        UpdateGroupEntity updatedGroupEntity = new UpdateGroupEntity();
+        updatedGroupEntity.setRoles(Maps.<RoleScope, String>builder().put(RoleScope.API, "PRIMARY_OWNER").put(RoleScope.APPLICATION, "PRIMARY_OWNER").build());
+
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(Mockito.mock(Group.class)));
+        when(permissionService.hasPermission(RolePermission.ENVIRONMENT_GROUP, "DEFAULT", CREATE, UPDATE, DELETE)).thenReturn(true);
+        when(membershipService.getRoles(any(),  any(),  any(),  any())).thenReturn(Collections.emptySet());
+
+        groupService.update(GROUP_ID, updatedGroupEntity);
+
+        verify(membershipService, never()).deleteReferenceMember(any(), any(), any(), any());
+        verify(membershipService, never()).addRoleToMemberOnReference(any(), any(), any());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <gravitee-common.version>1.20.0</gravitee-common.version>
         <gravitee-definition.version>1.26.0</gravitee-definition.version>
         <gravitee-plugin.version>1.16.0</gravitee-plugin.version>
-        <gravitee-repository.version>3.6.0</gravitee-repository.version>
+        <gravitee-repository.version>3.7.0-SNAPSHOT</gravitee-repository.version>
         <gravitee-gateway-api.version>1.20.1</gravitee-gateway-api.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-expression-language.version>1.5.0</gravitee-expression-language.version>


### PR DESCRIPTION
* add restriction to prevent defining PRIMARY_OWNER as default role in a group
* authorize at most 1 API PRIMARY OWNER member in a group
* add a boolean 'hasAPIPrimaryOwner' in the GroupEntity. It is computed only if needed.

Closes gravitee-io/issues#5133