### PR TITLE
Feature/5016 define group as po of an api

### DIFF
--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/TransferOwnership.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/model/TransferOwnership.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.management.rest.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.gravitee.rest.api.model.MembershipMemberType;
 
 import javax.validation.constraints.NotNull;
 
@@ -26,14 +27,19 @@ import javax.validation.constraints.NotNull;
 public class TransferOwnership {
 
     /**
-     * User identifier
+     * Member identifier
      */
     private String id;
 
     /**
-     * User reference
+     * Member reference
      */
     private String reference;
+
+    /**
+     * Member type
+     */
+    private MembershipMemberType type;
 
     @NotNull
     @JsonProperty("role")
@@ -61,5 +67,13 @@ public class TransferOwnership {
 
     public void setPoRole(String poRole) {
         this.poRole = poRole;
+    }
+
+    public MembershipMemberType getType() {
+        return type;
+    }
+
+    public void setType(MembershipMemberType type) {
+        this.type = type;
     }
 }

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiMembersResource.java
@@ -38,7 +38,6 @@ import javax.validation.constraints.NotNull;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.*;
 import javax.ws.rs.core.Response;
-import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -100,6 +99,7 @@ public class ApiMembersResource extends AbstractResource {
         apiService.findById(api);
         return membershipService.getMembersByReference(MembershipReferenceType.API, api)
                 .stream()
+                .filter(memberEntity -> memberEntity.getType() == MembershipMemberType.USER)
                 .map(MembershipListItem::new)
                 .sorted(Comparator.comparing(MembershipListItem::getId))
                 .collect(Collectors.toList());
@@ -168,7 +168,7 @@ public class ApiMembersResource extends AbstractResource {
 
         apiService.findById(api);
         membershipService.transferApiOwnership(api, new MembershipService.MembershipMember(
-                transferOwnership.getId(), transferOwnership.getReference(), MembershipMemberType.USER), newRoles);
+                transferOwnership.getId(), transferOwnership.getReference(), transferOwnership.getType()), newRoles);
         return Response.ok().build();
     }
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/GroupMembersResource.java
@@ -23,6 +23,7 @@ import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.service.GroupService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.NotifierService;
@@ -198,7 +199,11 @@ public class GroupMembersResource extends AbstractResource {
                                 updatedMembership.getId(),
                                 previousApiRole.getId());
                     }
-
+                    if (previousApiRole != null && previousApiRole.getName().equals(SystemRole.PRIMARY_OWNER.name())) {
+                        groupService.updateApiPrimaryOwner(group, null);
+                    } else if(roleName.equals(SystemRole.PRIMARY_OWNER.name())) {
+                        groupService.updateApiPrimaryOwner(group, updatedMembership.getId());
+                    }
                 }
                 
                 RoleEntity applicationRoleEntity = roleEntities.get(RoleScope.APPLICATION);

--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/GroupEntity.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/GroupEntity.java
@@ -16,7 +16,6 @@
 package io.gravitee.rest.api.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.gravitee.rest.api.model.permissions.RoleScope;
 
 import java.util.Date;
@@ -25,7 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com) 
+ * @author Nicolas GERAUD (nicolas.geraud at graviteesource.com)
  * @author GraviteeSource Team
  */
 public class GroupEntity {
@@ -52,6 +51,9 @@ public class GroupEntity {
     private boolean emailInvitation;
     @JsonProperty("disable_membership_notifications")
     private boolean disableMembershipNotifications;
+    private String apiPrimaryOwner;
+    @JsonProperty("primary_owner")
+    private boolean primaryOwner;
 
     public String getId() {
         return id;
@@ -157,6 +159,22 @@ public class GroupEntity {
         this.disableMembershipNotifications = disableMembershipNotifications;
     }
 
+    public String getApiPrimaryOwner() {
+        return apiPrimaryOwner;
+    }
+
+    public void setApiPrimaryOwner(String apiPrimaryOwner) {
+        this.apiPrimaryOwner = apiPrimaryOwner;
+    }
+
+    public boolean isPrimaryOwner() {
+        return primaryOwner;
+    }
+
+    public void setPrimaryOwner(boolean primaryOwner) {
+        this.primaryOwner = primaryOwner;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -186,6 +204,8 @@ public class GroupEntity {
                 ", systemInvitation=" + systemInvitation +
                 ", emailInvitation=" + emailInvitation +
                 ", disableMembershipNotifications=" + disableMembershipNotifications +
+                ", apiPrimaryOwner=" + apiPrimaryOwner +
+                ", primaryOwner=" + primaryOwner +
                 '}';
     }
 }

--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/MemberEntity.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/MemberEntity.java
@@ -35,8 +35,10 @@ public class MemberEntity {
 
     private String email;
 
+    private MembershipMemberType type;
+
     private MembershipReferenceType referenceType;
-    
+
     private String referenceId;
     
     private List<RoleEntity> roles;
@@ -121,6 +123,14 @@ public class MemberEntity {
         this.permissions = permissions;
     }
 
+    public MembershipMemberType getType() {
+        return type;
+    }
+
+    public void setType(MembershipMemberType type) {
+        this.type = type;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -128,7 +138,7 @@ public class MemberEntity {
 
         MemberEntity that = (MemberEntity) o;
 
-        return id.equals(that.id) && referenceType.equals(that.referenceType) && referenceId.equals(that.referenceId);
+        return id.equals(that.id) && type.equals(that.type) && referenceType.equals(that.referenceType) && referenceId.equals(that.referenceId);
     }
 
     @Override
@@ -136,6 +146,7 @@ public class MemberEntity {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((id == null) ? 0 : id.hashCode());
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
         result = prime * result + ((referenceId == null) ? 0 : referenceId.hashCode());
         result = prime * result + ((referenceType == null) ? 0 : referenceType.hashCode());
         return result;

--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/PrimaryOwnerEntity.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/PrimaryOwnerEntity.java
@@ -23,24 +23,40 @@ import io.swagger.annotations.ApiModelProperty;
  */
 public class PrimaryOwnerEntity {
     @ApiModelProperty(
-            value = "The user id.",
+            value = "The user or group id.",
             example = "005197cc-cc84-86a6-a75a-88f9772c67db")
-    private final String id;
+    private String id;
 
     @ApiModelProperty(
-            value = "The user email.",
+            value = "The user or group email.",
             example = "contact@gravitee.io")
-    private final String email;
+    private String email;
 
     @ApiModelProperty(
-            value = "The user display name.",
+            value = "The user or group display name.",
             example = "John Doe")
-    private final String displayName;
+    private String displayName;
+
+    @ApiModelProperty(
+        value = "The primary owner type",
+        example = "USER")
+    private String type;
+
+    public PrimaryOwnerEntity() {
+    }
 
     public PrimaryOwnerEntity(UserEntity user) {
         this.id = user.getId();
         this.email = user.getEmail();
         this.displayName = user.getDisplayName();
+        this.type = "USER";
+    }
+
+    public PrimaryOwnerEntity(GroupEntity group) {
+        this.id = group.getId();
+        this.email = null;
+        this.displayName = group.getName();
+        this.type = "GROUP";
     }
 
     public String getId() {
@@ -53,5 +69,25 @@ public class PrimaryOwnerEntity {
 
     public String getEmail() {
         return email;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public void setType(String type) {
+        this.type = type;
     }
 }

--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/parameters/Key.java
@@ -15,6 +15,8 @@
  */
 package io.gravitee.rest.api.model.parameters;
 
+import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
+
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -126,6 +128,7 @@ public enum Key {
     EMAIL_PROPERTIES_SSL_TRUST("email.properties.ssl.trust", new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
 
     API_LABELS_DICTIONARY("api.labelsDictionary", List.class, new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
+    API_PRIMARY_OWNER_MODE("api.primary.owner.mode", ApiPrimaryOwnerMode.HYBRID.name(), new HashSet<>(Arrays.asList(ENVIRONMENT, ORGANIZATION, SYSTEM))),
 
     CONSOLE_AUTHENTICATION_LOCALLOGIN_ENABLED("console.authentication.localLogin.enabled", "true", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),
     CONSOLE_SCHEDULER_TASKS("console.scheduler.tasks", "10", new HashSet<>(Arrays.asList(ORGANIZATION, SYSTEM))),

--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Api.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/Api.java
@@ -29,6 +29,8 @@ import java.util.List;
 public class Api {
     @ParameterKey(Key.API_LABELS_DICTIONARY)
     private List<String> labelsDictionary;
+    @ParameterKey(Key.API_PRIMARY_OWNER_MODE)
+    private String primaryOwnerMode;
 
     public List<String> getLabelsDictionary() {
         return labelsDictionary;
@@ -36,5 +38,13 @@ public class Api {
 
     public void setLabelsDictionary(List<String> labelsDictionary) {
         this.labelsDictionary = labelsDictionary;
+    }
+
+    public String getPrimaryOwnerMode() {
+        return primaryOwnerMode;
+    }
+
+    public void setPrimaryOwnerMode(String primaryOwnerMode) {
+        this.primaryOwnerMode = primaryOwnerMode;
     }
 }

--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ApiPrimaryOwnerMode.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/settings/ApiPrimaryOwnerMode.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.settings;
+
+public enum ApiPrimaryOwnerMode {
+    HYBRID, USER, GROUP;
+}

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMembersResourceTest.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApplicationMembersResourceTest.java
@@ -29,11 +29,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.mockito.internal.util.collections.Sets;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -71,7 +71,7 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
         memberEntity2.setId(MEMBER_2);
         doReturn(new Member().id(MEMBER_2)).when(memberMapper).convert(eq(memberEntity2), any());
         doReturn(new Member().id(MEMBER_1)).when(memberMapper).convert(eq(memberEntity1), any());
-        doReturn(new HashSet<>(Arrays.asList(memberEntity1, memberEntity2))).when(membershipService).getMembersByReference(MembershipReferenceType.APPLICATION, APPLICATION);
+        doReturn(Sets.newSet(memberEntity1, memberEntity2)).when(membershipService).getMembersByReference(MembershipReferenceType.APPLICATION, APPLICATION);
         doReturn(memberEntity1).when(membershipService).getUserMember(MembershipReferenceType.APPLICATION, APPLICATION, MEMBER_1);
         doReturn(null).when(membershipService).getUserMember(MembershipReferenceType.APPLICATION, APPLICATION, MEMBER_2);
 
@@ -88,8 +88,11 @@ public class ApplicationMembersResourceTest extends AbstractResourceTest {
 
         MembersResponse membersResponse = response.readEntity(MembersResponse.class);
         assertEquals(2, membersResponse.getData().size());
-        assertEquals(MEMBER_1, membersResponse.getData().get(0).getId());
-        assertEquals(MEMBER_2, membersResponse.getData().get(1).getId());
+        assertTrue(
+                (MEMBER_1.equals(membersResponse.getData().get(0).getId()) && MEMBER_2.equals(membersResponse.getData().get(1).getId())) ||
+                        (MEMBER_1.equals(membersResponse.getData().get(1).getId()) && MEMBER_2.equals(membersResponse.getData().get(0).getId()))
+                );
+
 
         Links links = membersResponse.getLinks();
         assertNotNull(links);

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -19,6 +19,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.*;
 import io.gravitee.rest.api.model.api.header.ApiHeaderEntity;
+import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 
 import java.util.Collection;
 import java.util.List;
@@ -143,4 +144,9 @@ public interface ApiService {
     boolean hasHealthCheckEnabled(ApiEntity api, boolean mustBeEnabledOnAllEndpoints);
 
     ApiEntity fetchMetadataForApi(ApiEntity apiEntity);
+
+    PrimaryOwnerEntity getPrimaryOwner(String apiId) throws TechnicalManagementException;
+
+    void addGroup(String api, String group);
+    void removeGroup(String api, String group);
 }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/GroupService.java
@@ -16,7 +16,10 @@
 package io.gravitee.rest.api.service;
 
 import io.gravitee.repository.management.model.GroupEvent;
-import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.ApplicationEntity;
+import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.NewGroupEntity;
+import io.gravitee.rest.api.model.UpdateGroupEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 
 import java.util.List;
@@ -28,8 +31,6 @@ import java.util.Set;
  * @author GraviteeSource Team
  */
 public interface GroupService {
-
-    void                    addUserToGroup                      (String groupId, String username, String... roleIds);
     GroupEntity             create                              (NewGroupEntity group);
     void                    delete                              (String groupId);
     void                    deleteUserFromGroup                 (String groupId, String username);
@@ -46,4 +47,5 @@ public interface GroupService {
     boolean                 isUserAuthorizedToAccessApiData     (ApiEntity api, List<String> excludedGroups, String username);
     boolean                 isUserAuthorizedToAccessPortalData  (List<String> excludedGroups, String username);
     GroupEntity             update                              (String groupId, UpdateGroupEntity group);
+    void                    updateApiPrimaryOwner               (String groupId, String newApiPrimaryOwner);
 }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/NoPrimaryOwnerGroupForUserException.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/NoPrimaryOwnerGroupForUserException.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import io.gravitee.common.http.HttpStatusCode;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+public class NoPrimaryOwnerGroupForUserException extends AbstractManagementException {
+
+    final String username;
+
+    public NoPrimaryOwnerGroupForUserException(String username) {
+        this.username = username;
+    }
+
+    @Override
+    public int getHttpStatusCode() {
+        return HttpStatusCode.BAD_REQUEST_400;
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "user.notInPrimaryOwnerGroup";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public String getMessage() {
+        return "User " + username + " must belongs to at least one group with a primary owner member.";
+    }
+
+}

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/StillPrimaryOwnerException.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/StillPrimaryOwnerException.java
@@ -16,6 +16,7 @@
 package io.gravitee.rest.api.service.exceptions;
 
 import io.gravitee.common.http.HttpStatusCode;
+import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,10 +31,18 @@ public class StillPrimaryOwnerException extends AbstractManagementException {
 
     private final long apiCount;
     private final long applicationCount;
+    private final ApiPrimaryOwnerMode primaryOwnerMode;
 
     public StillPrimaryOwnerException(long apiCount, long applicationCount) {
         this.apiCount = apiCount;
         this.applicationCount = applicationCount;
+        this.primaryOwnerMode = ApiPrimaryOwnerMode.USER;
+    }
+
+    public StillPrimaryOwnerException(long apiCount, ApiPrimaryOwnerMode primaryOwnerMode) {
+        this.apiCount = apiCount;
+        this.applicationCount = 0;
+        this.primaryOwnerMode = primaryOwnerMode;
     }
 
     @Override
@@ -43,12 +52,16 @@ public class StillPrimaryOwnerException extends AbstractManagementException {
 
     @Override
     public String getMessage() {
-        return "The user is still primary owner of '" + apiCount + "' APIs and '" + applicationCount + "' Applications.";
+        String message = "The " + primaryOwnerMode.name().toLowerCase() + " is still primary owner of '" + apiCount + "' APIs";
+        if (ApiPrimaryOwnerMode.USER == primaryOwnerMode) {
+            message += " and '" + applicationCount + "' Applications.";
+        }
+        return message;
     }
 
     @Override
     public String getTechnicalCode() {
-        return "user.notDeletable";
+        return primaryOwnerMode.name().toLowerCase() + ".notDeletable";
     }
 
     @Override
@@ -57,6 +70,7 @@ public class StillPrimaryOwnerException extends AbstractManagementException {
             {
                 put("apiCount", valueOf(apiCount));
                 put("applicationCount", valueOf(applicationCount));
+                put("primaryOwnerMode", primaryOwnerMode.name());
             }
         };
     }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/Api3_0VersionSerializer.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/Api3_0VersionSerializer.java
@@ -82,6 +82,10 @@ public class Api3_0VersionSerializer extends ApiSerializer {
             jsonGenerator.writeEndObject();
         }
 
+        if (apiEntity.getPrimaryOwner() != null) {
+            jsonGenerator.writeObjectField("primaryOwner", apiEntity.getPrimaryOwner());
+        }
+
         // must end the writing process
         jsonGenerator.writeEndObject();
     }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiDefaultSerializer.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiDefaultSerializer.java
@@ -74,6 +74,10 @@ public class ApiDefaultSerializer extends ApiSerializer {
             jsonGenerator.writeEndObject();
         }
 
+        if (apiEntity.getPrimaryOwner() != null) {
+            jsonGenerator.writeObjectField("primaryOwner", apiEntity.getPrimaryOwner());
+        }
+
         // must end the writing process
         jsonGenerator.writeEndObject();
     }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
@@ -151,16 +151,19 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
                 Set<MemberEntity> memberEntities = applicationContext.getBean(MembershipService.class).getMembersByReference(MembershipReferenceType.API, apiEntity.getId());
                 List<Member> members = new ArrayList<>(memberEntities == null ? 0 : memberEntities.size());
                 if (memberEntities != null) {
-                    memberEntities.forEach(m -> {
-                        UserEntity userEntity = applicationContext.getBean(UserService.class).findById(m.getId());
-                        if (userEntity != null) {
-                            Member member = new Member();
-                            member.setRoles(m.getRoles().stream().map(RoleEntity::getId).collect(Collectors.toList()));
-                            member.setSource(userEntity.getSource());
-                            member.setSourceId(userEntity.getSourceId());
-                            members.add(member);
-                        }
-                    });
+                    final UserService userService = applicationContext.getBean(UserService.class);
+                    memberEntities.stream()
+                            .filter(m -> m.getType() == MembershipMemberType.USER)
+                            .forEach(m -> {
+                                UserEntity userEntity = userService.findById(m.getId());
+                                if (userEntity != null) {
+                                    Member member = new Member();
+                                    member.setRoles(m.getRoles().stream().map(RoleEntity::getId).collect(Collectors.toList()));
+                                    member.setSource(userEntity.getSource());
+                                    member.setSourceId(userEntity.getSourceId());
+                                    members.add(member);
+                                }
+                            });
                 }
                 jsonGenerator.writeObjectField("members", members);
             }

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_CreateTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_CreateTest.java
@@ -26,6 +26,8 @@ import io.gravitee.repository.management.model.Visibility;
 import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.NewApiEntity;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.exceptions.ApiAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.ApiServiceImpl;
@@ -124,6 +126,7 @@ public class ApiService_CreateTest {
     @Before
     public void setUp() {
         when(notificationTemplateService.resolveInlineTemplateWithParam(anyString(), any(Reader.class), any())).thenReturn("toDecode=decoded-value");
+        when(parameterService.find(Key.API_PRIMARY_OWNER_MODE, ParameterReferenceType.ENVIRONMENT)).thenReturn("USER");
         reset(searchEngineService);
     }
 

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_ExportAsJsonTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_ExportAsJsonTest.java
@@ -156,7 +156,7 @@ public class ApiService_ExportAsJsonTest extends ApiService_ExportAsJsonTestSetu
         api.setEnvironmentId("DEFAULT");
         api.setGroups(Collections.singleton("my-group"));
         api.setEnvironmentId("DEFAULT");
-
+        
         // set proxy
         Proxy proxy = new Proxy();
         proxy.setVirtualHosts(Collections.singletonList(new VirtualHost("/test")));

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_ExportAsJsonTestSetup.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_ExportAsJsonTestSetup.java
@@ -160,12 +160,14 @@ public class ApiService_ExportAsJsonTestSetup {
         poRole.setId("API_PRIMARY_OWNER");
         MembershipEntity membership = new MembershipEntity();
         membership.setMemberId("johndoe");
+        membership.setMemberType(MembershipMemberType.USER);
         membership.setRoleId("API_PRIMARY_OWNER");
         when(membershipService.getPrimaryOwner(eq(MembershipReferenceType.API), eq(API_ID)))
             .thenReturn(membership);
 
         MemberEntity memberEntity = new MemberEntity();
         memberEntity.setId(membership.getMemberId());
+        memberEntity.setType(membership.getMemberType());
         memberEntity.setRoles(Collections.singletonList(poRole));
         when(membershipService.getMembersByReference(eq(MembershipReferenceType.API), eq(API_ID)))
             .thenReturn(Collections.singleton(memberEntity));

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindByIdTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindByIdTest.java
@@ -19,18 +19,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ser.PropertyFilter;
 import com.fasterxml.jackson.databind.ser.impl.SimpleFilterProvider;
 import io.gravitee.definition.jackson.datatype.GraviteeMapper;
-import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.repository.exceptions.TechnicalException;
+import io.gravitee.repository.management.api.ApiRepository;
+import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.model.MembershipEntity;
 import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.UserEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.ApiServiceImpl;
 import io.gravitee.rest.api.service.jackson.filter.ApiPermissionFilter;
-import io.gravitee.repository.exceptions.TechnicalException;
-import io.gravitee.repository.management.api.ApiRepository;
-import io.gravitee.repository.management.model.Api;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,6 +44,7 @@ import java.util.Collections;
 import java.util.Optional;
 
 import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -97,6 +98,7 @@ public class ApiService_FindByIdTest {
         MembershipEntity po = new MembershipEntity();
         po.setMemberId(USER_NAME);
         when(membershipService.getPrimaryOwner(MembershipReferenceType.API, API_ID)).thenReturn(po);
+        when(userService.findById(USER_NAME)).thenReturn(mock(UserEntity.class));
 
         final ApiEntity apiEntity = apiService.findById(API_ID);
 

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindPrimaryOwnerTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_FindPrimaryOwnerTest.java
@@ -1,0 +1,399 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import io.gravitee.rest.api.model.GroupEntity;
+import io.gravitee.rest.api.model.PrimaryOwnerEntity;
+import io.gravitee.rest.api.model.UserEntity;
+import io.gravitee.rest.api.model.parameters.Key;
+import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
+import io.gravitee.rest.api.service.exceptions.GroupNotFoundException;
+import io.gravitee.rest.api.service.exceptions.NoPrimaryOwnerGroupForUserException;
+import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
+import io.gravitee.rest.api.service.impl.ApiServiceImpl;
+import io.gravitee.rest.api.service.spring.ServiceConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ApiService_FindPrimaryOwnerTest {
+
+    private static final String CURRENT_USER = "myCurrentUser";
+    private static final String CURRENT_USER_PO_GROUP = "myCurrentUserPoGroup";
+    private static final String PO_GROUP_ID = "myPoGroup";
+    private static final String PO_USER_ID = "myPoUser";
+
+    @InjectMocks
+    private final ApiServiceImpl apiService = new ApiServiceImpl();
+
+    @Mock
+    private ParameterService parameterService;
+
+    @Mock
+    private GroupService groupService;
+
+    @Mock
+    private UserService userService;
+
+    @Spy
+    private final ObjectMapper objectMapper = (new ServiceConfiguration()).objectMapper();
+
+    // HYBRID + import with PO GROUP
+    @Test
+    public void testHybridModeWithExistingPOGroup() {
+        setPrimaryOwnerMode("HYBRID");
+        defineGroup(PO_GROUP_ID);
+
+        JsonNode definition = poGroupDefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(PO_GROUP_ID, primaryOwner.getId());
+        assertEquals("GROUP", primaryOwner.getType());
+    }
+
+    @Test
+    public void testHybridModeWithNonExistingPOGroupAndCurrentUserBelongsToAPoGroup() {
+        setPrimaryOwnerMode("HYBRID");
+        setPoGroupNonExisting();
+        addUserInPOGroup(CURRENT_USER, CURRENT_USER_PO_GROUP);
+
+        JsonNode definition = poGroupDefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(CURRENT_USER_PO_GROUP, primaryOwner.getId());
+        assertEquals("GROUP", primaryOwner.getType());
+    }
+
+    @Test
+    public void testHybridModeWithNonExistingPOGroupAndCurrentUserDoesNotBelongToAPoGroup() {
+        setPrimaryOwnerMode("HYBRID");
+        setPoGroupNonExisting();
+        setCurrentUserInNoPOGroup();
+        defineUser(CURRENT_USER);
+
+        JsonNode definition = poGroupDefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(CURRENT_USER, primaryOwner.getId());
+        assertEquals("USER", primaryOwner.getType());
+    }
+
+    // HYBRID + import with PO User
+    @Test
+    public void testHybridModeWithExistingPOUser() {
+        setPrimaryOwnerMode("HYBRID");
+        defineUser(PO_USER_ID);
+
+        JsonNode definition = poUserDefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(PO_USER_ID, primaryOwner.getId());
+        assertEquals("USER", primaryOwner.getType());
+    }
+
+    @Test
+    public void testHybridModeWithNonExistingPOUser() {
+        setPrimaryOwnerMode("HYBRID");
+        setPoUserNonExisting();
+        defineUser(CURRENT_USER);
+
+        JsonNode definition = poUserDefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(CURRENT_USER, primaryOwner.getId());
+        assertEquals("USER", primaryOwner.getType());
+    }
+
+    // HYBRID + import with no PO
+    @Test
+    public void testHybridModeWithNoPO() {
+        setPrimaryOwnerMode("HYBRID");
+        defineUser(CURRENT_USER);
+
+        JsonNode definition = noPODefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(CURRENT_USER, primaryOwner.getId());
+        assertEquals("USER", primaryOwner.getType());
+    }
+
+    // GROUP + import with PO GROUP
+    @Test
+    public void testGroupModeWithExistingPOGroup() {
+        setPrimaryOwnerMode("GROUP");
+        defineGroup(PO_GROUP_ID);
+
+        JsonNode definition = poGroupDefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(PO_GROUP_ID, primaryOwner.getId());
+        assertEquals("GROUP", primaryOwner.getType());
+    }
+
+    @Test
+    public void testGroupModeWithNonExistingPOGroupAndCurrentUserBelongsToAPoGroup() {
+        setPrimaryOwnerMode("GROUP");
+        setPoGroupNonExisting();
+        addUserInPOGroup(CURRENT_USER, CURRENT_USER_PO_GROUP);
+
+        JsonNode definition = poGroupDefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(CURRENT_USER_PO_GROUP, primaryOwner.getId());
+        assertEquals("GROUP", primaryOwner.getType());
+    }
+
+    @Test(expected = NoPrimaryOwnerGroupForUserException.class)
+    public void testGroupModeWithNonExistingPOGroupAndCurrentUserDoesNotBelongToAPoGroup() {
+        setPrimaryOwnerMode("GROUP");
+        setPoGroupNonExisting();
+        setCurrentUserInNoPOGroup();
+
+        JsonNode definition = poGroupDefinition();
+
+        apiService.findPrimaryOwner(definition, CURRENT_USER);
+    }
+
+    // GROUP + import with PO User
+    @Test
+    public void testGroupModeWithExistingPOUserAndPoUserBelongsToAPoGroup() {
+        setPrimaryOwnerMode("GROUP");
+        defineUser(PO_USER_ID);
+        addUserInPOGroup(PO_USER_ID, PO_GROUP_ID);
+
+        JsonNode definition = poUserDefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(PO_GROUP_ID, primaryOwner.getId());
+        assertEquals("GROUP", primaryOwner.getType());
+    }
+
+    @Test
+    public void testGroupModeWithExistingPOUserAndPoUserDoesNotBelongToAPoGroupAndCurrentUserBelongsToAPoGroup() {
+        setPrimaryOwnerMode("GROUP");
+        defineUser(PO_USER_ID);
+        setPoUserInNoPOGroup();
+        addUserInPOGroup(CURRENT_USER, CURRENT_USER_PO_GROUP);
+
+        JsonNode definition = poUserDefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(CURRENT_USER_PO_GROUP, primaryOwner.getId());
+        assertEquals("GROUP", primaryOwner.getType());
+    }
+
+    @Test(expected = NoPrimaryOwnerGroupForUserException.class)
+    public void testGroupModeWithExistingPOUserAndPoUserDoesNotBelongToAPoGroupAndCurrentUserDoesNotBelongToAPoGroup() {
+        setPrimaryOwnerMode("GROUP");
+        defineUser(PO_USER_ID);
+        setCurrentUserInNoPOGroup();
+        setPoUserInNoPOGroup();
+
+        JsonNode definition = poUserDefinition();
+
+        apiService.findPrimaryOwner(definition, CURRENT_USER);
+    }
+
+    @Test
+    public void testGroupModeWithNonExistingPOUserAndCurrentUserBelongsToAPoGroup() {
+        setPrimaryOwnerMode("GROUP");
+        addUserInPOGroup(CURRENT_USER, CURRENT_USER_PO_GROUP);
+        setPoUserNonExisting();
+
+        JsonNode definition = poUserDefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(CURRENT_USER_PO_GROUP, primaryOwner.getId());
+        assertEquals("GROUP", primaryOwner.getType());
+    }
+
+    @Test(expected = NoPrimaryOwnerGroupForUserException.class)
+    public void testGroupModeWithNonExistingPOUserAndCurrentUserDoesNotBelongToAPoGroup() {
+        setPrimaryOwnerMode("GROUP");
+        setPoUserNonExisting();
+        setCurrentUserInNoPOGroup();
+
+        JsonNode definition = poUserDefinition();
+
+        apiService.findPrimaryOwner(definition, CURRENT_USER);
+    }
+
+    // GROUP + import with no PO
+    @Test
+    public void testGroupModeWithNoPOAndCurrentUserBelongsToAPoGroup() {
+        setPrimaryOwnerMode("GROUP");
+        addUserInPOGroup(CURRENT_USER, CURRENT_USER_PO_GROUP);
+
+        JsonNode definition = noPODefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(CURRENT_USER_PO_GROUP, primaryOwner.getId());
+        assertEquals("GROUP", primaryOwner.getType());
+    }
+
+    @Test(expected = NoPrimaryOwnerGroupForUserException.class)
+    public void testGroupModeWithNoPOAndCurrentUserDoesNotBelongToAPoGroup() {
+        setPrimaryOwnerMode("GROUP");
+        setCurrentUserInNoPOGroup();
+
+        JsonNode definition = noPODefinition();
+
+        apiService.findPrimaryOwner(definition, CURRENT_USER);
+    }
+
+    // USER + import with PO GROUP
+    @Test
+    public void testUserModeWithPOGroup() {
+        setPrimaryOwnerMode("USER");
+        defineUser(CURRENT_USER);
+
+        JsonNode definition = poGroupDefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(CURRENT_USER, primaryOwner.getId());
+        assertEquals("USER", primaryOwner.getType());
+    }
+
+    // USER + import with PO User
+    @Test
+    public void testUserModeWithExistingPOUser() {
+        setPrimaryOwnerMode("USER");
+        defineUser(PO_USER_ID);
+
+        JsonNode definition = poUserDefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(PO_USER_ID, primaryOwner.getId());
+        assertEquals("USER", primaryOwner.getType());
+    }
+
+    @Test
+    public void testUserModeWithNonExistingPOUser() {
+        setPrimaryOwnerMode("USER");
+        setPoUserNonExisting();
+        defineUser(CURRENT_USER);
+
+        JsonNode definition = poUserDefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(CURRENT_USER, primaryOwner.getId());
+        assertEquals("USER", primaryOwner.getType());
+    }
+
+    // USER + import with no PO
+    @Test
+    public void testUserModeWithNoPO() {
+        setPrimaryOwnerMode("USER");
+        defineUser(CURRENT_USER);
+
+        JsonNode definition = noPODefinition();
+
+        final PrimaryOwnerEntity primaryOwner = apiService.findPrimaryOwner(definition, CURRENT_USER);
+        assertEquals(CURRENT_USER, primaryOwner.getId());
+        assertEquals("USER", primaryOwner.getType());
+    }
+
+
+    // Helpers
+    private JsonNode noPODefinition() {
+        return JsonNodeFactory.instance.objectNode();
+    }
+
+    private JsonNode poGroupDefinition() {
+        return JsonNodeFactory.instance.objectNode()
+                .set("primaryOwner", JsonNodeFactory.instance.objectNode()
+                        .put("id", PO_GROUP_ID)
+                        .put("type", "GROUP"));
+    }
+
+    private JsonNode poUserDefinition() {
+        return JsonNodeFactory.instance.objectNode()
+                .set("primaryOwner", JsonNodeFactory.instance.objectNode()
+                        .put("id", PO_USER_ID)
+                        .put("type", "USER"));
+    }
+
+
+    private void setPrimaryOwnerMode(String mode) {
+        when(parameterService.find(Key.API_PRIMARY_OWNER_MODE, ParameterReferenceType.ENVIRONMENT)).thenReturn(mode);
+    }
+
+    private void addUserInPOGroup(String username, String poGroup) {
+        GroupEntity userPoGroup = new GroupEntity();
+        userPoGroup.setId(poGroup);
+        userPoGroup.setApiPrimaryOwner("PO-of-current_user-po-group");
+        GroupEntity aNonPoGroup = new GroupEntity();
+        aNonPoGroup.setId("aNonPoGroup");
+        aNonPoGroup.setApiPrimaryOwner(null);
+        when(groupService.findByUser(username)).thenReturn(new HashSet<>(Arrays.asList(userPoGroup, aNonPoGroup)));
+    }
+
+    private void setCurrentUserInNoPOGroup() {
+        GroupEntity aNonPoGroup = new GroupEntity();
+        aNonPoGroup.setId("aNonPoGroup");
+        aNonPoGroup.setApiPrimaryOwner(null);
+        GroupEntity anotherNonPoGroup = new GroupEntity();
+        anotherNonPoGroup.setId("anotherNonPoGroup");
+        anotherNonPoGroup.setApiPrimaryOwner(null);
+        when(groupService.findByUser(CURRENT_USER)).thenReturn(new HashSet<>(Arrays.asList(aNonPoGroup, anotherNonPoGroup)));
+    }
+
+    private void setPoUserInNoPOGroup() {
+        GroupEntity aNonPoGroup = new GroupEntity();
+        aNonPoGroup.setId("aNonPoGroup");
+        aNonPoGroup.setApiPrimaryOwner(null);
+        GroupEntity anotherNonPoGroup = new GroupEntity();
+        anotherNonPoGroup.setId("anotherNonPoGroup");
+        anotherNonPoGroup.setApiPrimaryOwner(null);
+        when(groupService.findByUser(PO_USER_ID)).thenReturn(new HashSet<>(Arrays.asList(aNonPoGroup, anotherNonPoGroup)));
+    }
+
+    private void defineUser(String username) {
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(username);
+        when(userService.findById(username)).thenReturn(userEntity);
+    }
+
+    private void defineGroup(String groupId) {
+        GroupEntity groupEntity = new GroupEntity();
+        groupEntity.setId(groupId);
+        when(groupService.findById(groupId)).thenReturn(groupEntity);
+    }
+
+    private void setPoUserNonExisting() {
+        when(userService.findById(PO_USER_ID)).thenThrow(new UserNotFoundException(PO_USER_ID));
+    }
+
+    private void setPoGroupNonExisting() {
+        when(groupService.findById(PO_GROUP_ID)).thenThrow(new GroupNotFoundException(PO_GROUP_ID));
+    }
+}

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_UpdateWithDefinitionTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_UpdateWithDefinitionTest.java
@@ -121,6 +121,9 @@ public class ApiService_UpdateWithDefinitionTest {
     @Before
     public void setUp() {
         when(notificationTemplateService.resolveInlineTemplateWithParam(anyString(), any(Reader.class), any())).thenReturn("toDecode=decoded-value");
+        MembershipEntity primaryOwner = new MembershipEntity();
+        primaryOwner.setMemberType(MembershipMemberType.USER);
+        when(membershipService.getPrimaryOwner(eq(MembershipReferenceType.API), any())).thenReturn(primaryOwner);
         reset(searchEngineService);
     }
 

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_Update_DefaultLoggingMaxDurationTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_Update_DefaultLoggingMaxDurationTest.java
@@ -27,6 +27,9 @@ import io.gravitee.repository.management.api.ApiRepository;
 import io.gravitee.repository.management.model.Api;
 import io.gravitee.repository.management.model.ApiLifecycleState;
 import io.gravitee.rest.api.model.MemberEntity;
+import io.gravitee.rest.api.model.MembershipEntity;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
 import io.gravitee.rest.api.model.RoleEntity;
 import io.gravitee.rest.api.model.api.UpdateApiEntity;
 import io.gravitee.rest.api.model.parameters.Key;
@@ -179,6 +182,10 @@ public class ApiService_Update_DefaultLoggingMaxDurationTest {
         SecurityContextHolder.setContext(securityContext);
 
         when(notificationTemplateService.resolveInlineTemplateWithParam(anyString(), any(Reader.class), any())).thenReturn("toDecode=decoded-value");
+        when(parameterService.find(Key.API_PRIMARY_OWNER_MODE, ParameterReferenceType.ENVIRONMENT)).thenReturn("USER");
+        MembershipEntity primaryOwner = new MembershipEntity();
+        primaryOwner.setMemberType(MembershipMemberType.USER);
+        when(membershipService.getPrimaryOwner(eq(MembershipReferenceType.API), any())).thenReturn(primaryOwner);
         reset(searchEngineService);
     }
 

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_gRPC_ExportAsJsonTestSetup.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_gRPC_ExportAsJsonTestSetup.java
@@ -161,12 +161,14 @@ public class ApiService_gRPC_ExportAsJsonTestSetup {
         poRole.setId("API_PRIMARY_OWNER");
         MembershipEntity membership = new MembershipEntity();
         membership.setMemberId("johndoe");
+        membership.setMemberType(MembershipMemberType.USER);
         membership.setRoleId("API_PRIMARY_OWNER");
         when(membershipService.getPrimaryOwner(eq(MembershipReferenceType.API), eq(API_ID)))
             .thenReturn(membership);
 
         MemberEntity memberEntity = new MemberEntity();
         memberEntity.setId(membership.getMemberId());
+        memberEntity.setType(membership.getMemberType());
         memberEntity.setRoles(Collections.singletonList(poRole));
         when(membershipService.getMembersByReference(eq(MembershipReferenceType.API), eq(API_ID)))
             .thenReturn(Collections.singleton(memberEntity));

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_UpdateTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/GroupService_UpdateTest.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service;
+
+import io.gravitee.common.util.Maps;
+import io.gravitee.repository.management.api.GroupRepository;
+import io.gravitee.repository.management.model.Group;
+import io.gravitee.rest.api.model.MembershipMemberType;
+import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.UpdateGroupEntity;
+import io.gravitee.rest.api.model.permissions.RolePermission;
+import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.impl.GroupServiceImpl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static io.gravitee.rest.api.model.permissions.RolePermissionAction.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author Florent CHAMFROY (florent.chamfroy at graviteesource.com)
+ * @author GraviteeSource Team
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class GroupService_UpdateTest {
+
+    private static final String GROUP_ID = "my-group-id";
+
+    @InjectMocks
+    private final GroupService groupService = new GroupServiceImpl();
+
+    @Mock
+    private GroupRepository groupRepository;
+
+    @Mock
+    private MembershipService membershipService;
+
+    @Mock
+    private PermissionService permissionService;
+
+    @Mock
+    private AuditService auditService;
+
+    @Test
+    public void shouldUpdateGroup() throws Exception {
+
+        UpdateGroupEntity updatedGroupEntity = new UpdateGroupEntity();
+        updatedGroupEntity.setDisableMembershipNotifications(true);
+        updatedGroupEntity.setEmailInvitation(true);
+        updatedGroupEntity.setEventRules(null);
+        updatedGroupEntity.setLockApiRole(true);
+        updatedGroupEntity.setLockApplicationRole(true);
+        updatedGroupEntity.setMaxInvitation(100);
+        updatedGroupEntity.setName("my-group-name");
+        updatedGroupEntity.setRoles(Maps.<RoleScope, String>builder().put(RoleScope.API, "OWNER").build());
+        updatedGroupEntity.setSystemInvitation(false);
+
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(Mockito.mock(Group.class)));
+        when(permissionService.hasPermission(RolePermission.ENVIRONMENT_GROUP, "DEFAULT", CREATE, UPDATE, DELETE)).thenReturn(true);
+        when(membershipService.getRoles(any(),  any(),  any(),  any())).thenReturn(Collections.emptySet());
+
+        groupService.update(GROUP_ID, updatedGroupEntity);
+
+        verify(groupRepository).update(
+                argThat(
+                        group -> group.isDisableMembershipNotifications() &&
+                                group.isEmailInvitation() &&
+                                group.getEventRules() == null &&
+                                group.isLockApiRole() &&
+                                group.isLockApplicationRole() &&
+                                group.getMaxInvitation() == 100 &&
+                                group.getName().equals("my-group-name") &&
+                                !group.isSystemInvitation()
+                )
+        );
+
+        verify(membershipService).addRoleToMemberOnReference(
+                argThat(membershipReference -> membershipReference.getType() == MembershipReferenceType.API && membershipReference.getId() == null),
+                argThat(membershipMember -> membershipMember.getMemberId().equals(GROUP_ID) && membershipMember.getReference() == null && membershipMember.getMemberType() == MembershipMemberType.GROUP),
+                argThat(membershipRole -> membershipRole.getScope() == RoleScope.API && membershipRole.getName().equals("OWNER"))
+        );
+    }
+
+    @Test
+    public void shouldNotUpdateDefaultRoleBecausePrimaryOwner() throws Exception {
+
+        UpdateGroupEntity updatedGroupEntity = new UpdateGroupEntity();
+        updatedGroupEntity.setRoles(Maps.<RoleScope, String>builder().put(RoleScope.API, "PRIMARY_OWNER").put(RoleScope.APPLICATION, "PRIMARY_OWNER").build());
+
+        when(groupRepository.findById(GROUP_ID)).thenReturn(Optional.of(Mockito.mock(Group.class)));
+        when(permissionService.hasPermission(RolePermission.ENVIRONMENT_GROUP, "DEFAULT", CREATE, UPDATE, DELETE)).thenReturn(true);
+        when(membershipService.getRoles(any(),  any(),  any(),  any())).thenReturn(Collections.emptySet());
+
+        groupService.update(GROUP_ID, updatedGroupEntity);
+
+        verify(membershipService, never()).deleteReferenceMember(any(), any(), any(), any());
+        verify(membershipService, never()).addRoleToMemberOnReference(any(), any(), any());
+    }
+}

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_0.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_0.json
@@ -3,6 +3,11 @@
   "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
   "flow_mode": "DEFAULT",
   "groups": [
     "My Group"
@@ -86,8 +91,8 @@
     "logging": {
       "mode": "CLIENT_PROXY",
       "condition": "condition",
-      "content":"NONE",
-      "scope":"NONE"
+      "content": "NONE",
+      "scope": "NONE"
     },
     "groups": [
       {

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport.json
@@ -4,6 +4,11 @@
   "resources": [],
   "properties": [],
   "flow_mode": "DEFAULT",
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
   "groups": [
     "My Group"
   ],

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_0.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_0.json
@@ -3,6 +3,11 @@
   "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
   "flow_mode": "DEFAULT",
   "groups": [
     "My Group"

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers.json
@@ -3,6 +3,11 @@
   "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
   "flow_mode": "DEFAULT",
   "groups": [
     "My Group"

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_0.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_0.json
@@ -3,6 +3,11 @@
   "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
   "flow_mode": "DEFAULT",
   "groups": [
     "My Group"

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata.json
@@ -3,6 +3,11 @@
   "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
   "flow_mode": "DEFAULT",
   "groups": [
     "My Group"

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-3_0.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-3_0.json
@@ -3,6 +3,11 @@
   "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
   "flow_mode": "DEFAULT",
   "groups": [
     "My Group"

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages.json
@@ -3,6 +3,11 @@
   "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
   "flow_mode": "DEFAULT",
   "groups": [
     "My Group"

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-3_0.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-3_0.json
@@ -3,6 +3,11 @@
   "gravitee": "1.0.0",
   "resources": [],
   "properties" : [ ],
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
   "flow_mode": "DEFAULT",
   "groups": [
     "My Group"

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans.json
@@ -4,6 +4,11 @@
   "resources": [],
   "properties" : [ ],
   "flow_mode": "DEFAULT",
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
   "groups": [
     "My Group"
   ],

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0.json
@@ -3,6 +3,11 @@
   "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
   "flow_mode": "DEFAULT",
   "groups": [
     "My Group"

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0V2.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0V2.json
@@ -3,6 +3,11 @@
   "gravitee": "2.0.0",
   "resources": [],
   "properties": [],
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
   "flow_mode": "DEFAULT",
   "groups": [
     "My Group"

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport.json
@@ -3,6 +3,11 @@
   "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
+  "primaryOwner": {
+    "id": "johndoe",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
   "flow_mode": "DEFAULT",
   "groups": [
     "My Group"

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api.definition+primaryOwner.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api.definition+primaryOwner.json
@@ -1,0 +1,112 @@
+{
+  "name": "test",
+  "version": "1",
+  "description": "bmll",
+  "visibility": "PRIVATE",
+  "lifecycle_state": "CREATED",
+  "tags": [],
+  "primaryOwner": {
+    "id": "user",
+    "displayName": "johndoe-sourceId",
+    "type": "USER"
+  },
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://google.fr",
+        "weight": 1,
+        "backup": false,
+        "healthcheck": true
+      }
+    ],
+    "load_balancing": {
+      "type": "ROUND_ROBIN"
+    },
+    "failover": {
+      "maxAttempts": 1,
+      "retryTimeout": 0,
+      "cases": [
+        "TIMEOUT"
+      ]
+    },
+    "strip_context_path": false,
+    "http": {
+      "configuration": {
+        "connectTimeout": 5000,
+        "idleTimeout": 60000,
+        "keepAlive": true,
+        "dumpRequest": false,
+        "readTimeout": 10000,
+        "pipelining": false,
+        "maxConcurrentConnections": 100,
+        "useCompression": false
+      }
+    }
+  },
+  "paths": {
+    "/": [
+      {
+        "methods": [
+          "CONNECT",
+          "DELETE",
+          "GET",
+          "HEAD",
+          "OPTIONS",
+          "PATCH",
+          "POST",
+          "PUT",
+          "TRACE"
+        ],
+        "api-key": {}
+      },
+      {
+        "methods": [
+          "GET",
+          "POST",
+          "PUT",
+          "DELETE",
+          "HEAD",
+          "PATCH",
+          "OPTIONS",
+          "TRACE",
+          "CONNECT"
+        ],
+        "cache": {
+          "cacheName": null,
+          "key": null,
+          "timeToLiveSeconds": null,
+          "useResponseCacheHeaders": null,
+          "scope": null
+        },
+        "description": "Description of the Cache Gravitee Policy"
+      }
+    ]
+  },
+  "properties": {
+    "prop1": "value1"
+  },
+  "services": {},
+  "resources": [
+    {
+      "name": "cache_name",
+      "type": "cache",
+      "enabled": true,
+      "configuration": {
+        "name": "my-cache",
+        "timeToIdleSeconds": 1,
+        "timeToLiveSeconds": 2,
+        "maxEntriesLocalHeap": 1000
+      }
+    }
+  ],
+  "response_templates": {
+    "API_KEY_MISSING": {
+      "*/*": {
+        "status": 400,
+        "body": "{\"bad\":\"news\"}"
+      }
+    }
+  }
+}

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api.definition+primaryOwnerGroup.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/import-api.definition+primaryOwnerGroup.json
@@ -1,0 +1,111 @@
+{
+  "name": "test",
+  "version": "1",
+  "description": "bmll",
+  "visibility": "PRIVATE",
+  "lifecycle_state": "CREATED",
+  "tags": [],
+  "primaryOwner": {
+    "id": "group",
+    "type": "GROUP"
+  },
+  "proxy": {
+    "context_path": "/test",
+    "endpoints": [
+      {
+        "name": "default",
+        "target": "http://google.fr",
+        "weight": 1,
+        "backup": false,
+        "healthcheck": true
+      }
+    ],
+    "load_balancing": {
+      "type": "ROUND_ROBIN"
+    },
+    "failover": {
+      "maxAttempts": 1,
+      "retryTimeout": 0,
+      "cases": [
+        "TIMEOUT"
+      ]
+    },
+    "strip_context_path": false,
+    "http": {
+      "configuration": {
+        "connectTimeout": 5000,
+        "idleTimeout": 60000,
+        "keepAlive": true,
+        "dumpRequest": false,
+        "readTimeout": 10000,
+        "pipelining": false,
+        "maxConcurrentConnections": 100,
+        "useCompression": false
+      }
+    }
+  },
+  "paths": {
+    "/": [
+      {
+        "methods": [
+          "CONNECT",
+          "DELETE",
+          "GET",
+          "HEAD",
+          "OPTIONS",
+          "PATCH",
+          "POST",
+          "PUT",
+          "TRACE"
+        ],
+        "api-key": {}
+      },
+      {
+        "methods": [
+          "GET",
+          "POST",
+          "PUT",
+          "DELETE",
+          "HEAD",
+          "PATCH",
+          "OPTIONS",
+          "TRACE",
+          "CONNECT"
+        ],
+        "cache": {
+          "cacheName": null,
+          "key": null,
+          "timeToLiveSeconds": null,
+          "useResponseCacheHeaders": null,
+          "scope": null
+        },
+        "description": "Description of the Cache Gravitee Policy"
+      }
+    ]
+  },
+  "properties": {
+    "prop1": "value1"
+  },
+  "services": {},
+  "resources": [
+    {
+      "name": "cache_name",
+      "type": "cache",
+      "enabled": true,
+      "configuration": {
+        "name": "my-cache",
+        "timeToIdleSeconds": 1,
+        "timeToLiveSeconds": 2,
+        "maxEntriesLocalHeap": 1000
+      }
+    }
+  ],
+  "response_templates": {
+    "API_KEY_MISSING": {
+      "*/*": {
+        "status": 400,
+        "body": "{\"bad\":\"news\"}"
+      }
+    }
+  }
+}

--- a/gravitee-rest-api-services/gravitee-rest-api-services-sync/src/main/java/io/gravitee/rest/api/services/sync/SyncManager.java
+++ b/gravitee-rest-api-services/gravitee-rest-api-services-sync/src/main/java/io/gravitee/rest/api/services/sync/SyncManager.java
@@ -25,10 +25,9 @@ import io.gravitee.repository.management.api.search.ApiFieldExclusionFilter;
 import io.gravitee.repository.management.api.search.EventCriteria;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.model.*;
-import io.gravitee.repository.management.model.EventType;
-import io.gravitee.rest.api.model.*;
-import io.gravitee.rest.api.model.MembershipReferenceType;
+import io.gravitee.rest.api.model.EnvironmentEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.UserService;
@@ -81,6 +80,8 @@ public class SyncManager {
     private UserService userService;
     @Autowired
     private EnvironmentService environmentService;
+    @Autowired
+    private ApiService apiService;
 
     private final AtomicLong counter = new AtomicLong(0);
 
@@ -335,9 +336,7 @@ public class SyncManager {
         EnvironmentEntity environmentEntity = this.environmentService.findById(api.getEnvironmentId());
         GraviteeContext.setCurrentOrganization(environmentEntity.getOrganizationId());
 
-        MembershipEntity optPrimaryOwner = membershipService.getPrimaryOwner(MembershipReferenceType.API, api.getId());
-        final UserEntity user = userService.findById(optPrimaryOwner.getMemberId());
-        apiEntity.setPrimaryOwner(new PrimaryOwnerEntity(user));
+        apiEntity.setPrimaryOwner(apiService.getPrimaryOwner(api.getId()));
 
         return apiEntity;
     }


### PR DESCRIPTION
* Manage API PO in a group
  * add restriction to prevent defining PRIMARY_OWNER as default role in a group
  * authorize at most 1 API PRIMARY OWNER member in a group
  * return the API primary owner of the group. It is maintained up to date on every action on group members.

* Manage po groups in import/export of an api
* Prevent po group to be added to an API
* Allow transfer ownership to a group
* Add a "group only" mode
  * clean code
  * add a new parameter to manage primary owner mode
  * use this parameter to determine the way API creation from definition is done
  * keep only user members in export
  * when a group is po of an API, it is also attached to the API. When this group is no more a PO, it is removed from API groups.

Closes gravitee-io/issues#5133
Closes gravitee-io/issues#5135
Closes gravitee-io/issues#5136
Closes gravitee-io/issues#5137
Closes gravitee-io/issues#5162
