### PR TITLE
fix: Do not use system proxy by default for OAuth authentication

### DIFF
--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/JerseyClientBuilder.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/JerseyClientBuilder.java
@@ -129,17 +129,15 @@ public class JerseyClientBuilder {
     }
 
     private static Proxy buildProxy(Environment environment, String type) {
-
-        final String proxyHost = environment.getProperty("httpClient.proxy." + type + ".host", String.class, environment.getProperty("http.proxyHost"));
-        final Integer proxyPort = environment.getProperty("httpClient.proxy." + type + ".port", Integer.class, environment.getProperty("http.proxyPort", Integer.class, 3124));
-
-        Proxy.Type pType = Proxy.Type.HTTP;
-
-        if (useSockProxy(environment, type)) {
-            pType = Proxy.Type.SOCKS;
-        }
+        final String proxyHost = environment.getProperty("httpClient.proxy." + type + ".host", String.class);
+        final Integer proxyPort = environment.getProperty("httpClient.proxy." + type + ".port", Integer.class, 3124);
 
         if (proxyHost != null) {
+            Proxy.Type pType = Proxy.Type.HTTP;
+
+            if (useSockProxy(environment, type)) {
+                pType = Proxy.Type.SOCKS;
+            }
             return new Proxy(pType, new InetSocketAddress(proxyHost, proxyPort));
         }
 


### PR DESCRIPTION
Closes gravitee-io/issues#5281