### PR TITLE
fix(management): update dates of a category

### DIFF
--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/CategoryService_CreateTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/CategoryService_CreateTest.java
@@ -64,7 +64,7 @@ public class CategoryService_CreateTest {
     public void shouldCreateCategory() throws TechnicalException {
         NewCategoryEntity v1 = new NewCategoryEntity();
         v1.setName("v1");
-        when(mockCategoryRepository.create(any())).thenReturn(new Category());
+        when(mockCategoryRepository.create(argThat(cat -> cat.getCreatedAt() != null))).thenReturn(new Category());
         when(mockEnvironmentService.findById("DEFAULT")).thenReturn(new EnvironmentEntity());
         CategoryEntity category = categoryService.create(v1);
 

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/CategoryService_UpdateTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/CategoryService_UpdateTest.java
@@ -97,7 +97,7 @@ public class CategoryService_UpdateTest {
         when(updatedCategory.isHidden()).thenReturn(true);
         when(updatedCategory.getUpdatedAt()).thenReturn(new Date(1234567890L));
         when(updatedCategory.getCreatedAt()).thenReturn(new Date(9876543210L));
-        when(mockCategoryRepository.update(any())).thenReturn(updatedCategory);
+        when(mockCategoryRepository.update(argThat(cat -> cat.getUpdatedAt() != null))).thenReturn(updatedCategory);
 
         List<CategoryEntity> list = categoryService.update(singletonList(mockCategory));
 
@@ -130,7 +130,7 @@ public class CategoryService_UpdateTest {
         when(updatedCategory.isHidden()).thenReturn(true);
         when(updatedCategory.getUpdatedAt()).thenReturn(new Date(1234567890L));
         when(updatedCategory.getCreatedAt()).thenReturn(new Date(9876543210L));
-        when(mockCategoryRepository.update(any())).thenReturn(updatedCategory);
+        when(mockCategoryRepository.update(argThat(cat -> cat.getUpdatedAt() != null))).thenReturn(updatedCategory);
 
         CategoryEntity category = categoryService.update("category-id", mockCategory);
 


### PR DESCRIPTION
* modify the CategoryUpgrader to add a creation date
* add a creation date when creating a category
* add an update date when updating a category
* modify the way the hash for the picture is computed (use now the creation date if the update date is null)

Fixes gravitee-io/issues#5275