### PR TITLE
fix(management): use 'portal' query param

### DIFF
--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -141,7 +141,7 @@ public class ApisResource extends AbstractResource {
                 apiQuery.setLifecycleStates(singletonList(PUBLISHED));
             }
             if (isAuthenticated()) {
-                apis = apiService.findByUser(getAuthenticatedUser(), apiQuery, sortable, commonPageable,false);
+                apis = apiService.findByUser(getAuthenticatedUser(), apiQuery, sortable, commonPageable, apisParam.isPortal());
             } else {
                 apiQuery.setVisibility(PUBLIC);
                 apis = apiService.search(apiQuery, sortable, commonPageable);


### PR DESCRIPTION
When looking for APIs to subscribe from an application, we need to list the same APIs as if the user were on portal. To do this, we can use the query param 'portal' (which is only use for that case) to determine which APIs should be returned.

The application owner will be able to see only the published APIs that are public or of which he is a member.

Fixes gravitee-io/issues#5223