### PR TITLE
fix(management): keep compatibility with excluded_groups in pages

### DIFF
--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/PageEntity.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/PageEntity.java
@@ -41,6 +41,8 @@ public class PageEntity implements Indexable {
     private boolean homepage;
     private String parentId;
     private String parentPath;
+    @JsonProperty("excluded_groups")
+    private List<String> excludedGroups;
     private boolean excludedAccessControls;
     private Set<AccessControlEntity> accessControls;
     private List<String> messages ;
@@ -229,6 +231,14 @@ public class PageEntity implements Indexable {
         this.visibility = visibility;
     }
 
+    public List<String> getExcludedGroups() {
+        return excludedGroups;
+    }
+
+    public void setExcludedGroups(List<String> excludedGroups) {
+        this.excludedGroups = excludedGroups;
+    }
+
     public void setExcludedAccessControls(boolean excludedAccessControls) {
         this.excludedAccessControls = excludedAccessControls;
     }
@@ -280,6 +290,7 @@ public class PageEntity implements Indexable {
 				", homepage=" + homepage +
 				", parentId='" + parentId + '\'' +
                 ", parentPath='" + parentPath + '\'' +
+                ", excludedGroups=" + excludedGroups +
                 ", excludedAccessControls='" + excludedAccessControls + '\'' +
                 ", accessControls='" + accessControls + '\'' +
                 ", attachedMedia=" + attachedMedia +

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -700,7 +700,6 @@ public class PageServiceImpl extends AbstractService implements PageService, App
                     accessControl.setReferenceId(groupId);
                     return accessControl;
                 })).collect(Collectors.toSet()));
-                newPageEntity.setExcludedGroups(Collections.emptyList());
             }
 
             if (PageType.TRANSLATION.equals(newPageType)) {
@@ -989,7 +988,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
                 })).collect(Collectors.toSet()));
 
                 updatePageEntity.setAccessControls(accessControlEntities);
-                updatePageEntity.setExcludedGroups(Collections.emptyList());
+                updatePageEntity.setExcludedGroups(updatePageEntity.getExcludedGroups());
             }
 
             if (partial) {
@@ -2022,6 +2021,14 @@ public class PageServiceImpl extends AbstractService implements PageService, App
         }
         pageEntity.setExcludedAccessControls(page.isExcludedAccessControls());
         pageEntity.setAccessControls(PageServiceImpl.convertToEntities(page.getAccessControls()));
+
+        if(page.isExcludedAccessControls() && Visibility.PRIVATE.name().equals(page.getVisibility())) {
+            List<String> excludedGroups = page.getAccessControls().stream()
+                .filter(accessControl -> AccessControlReferenceType.GROUP.name().equals(accessControl.getReferenceType()))
+                .map(accessControl -> accessControl.getReferenceId()).collect(toList());
+            pageEntity.setExcludedGroups(excludedGroups);
+        }
+
         pageEntity.setParentId("".equals(page.getParentId()) ? null : page.getParentId());
         pageEntity.setMetadata(page.getMetadata());
 

--- a/postman/test/gio_apis.json
+++ b/postman/test/gio_apis.json
@@ -10289,6 +10289,7 @@
 											"var page = pm.response.json();",
 											"",
 											"pm.test(\"Should have excluded group\", function() {",
+											"    pm.expect(page.excluded_groups).to.have.members([pm.collectionVariables.get(\"created_reader_group_id\")]);",
 											"    pm.expect(page.visibility).to.eql(\"private\");",
 											"    pm.expect(page.excludedAccessControls).to.be.true;",
 											"    pm.expect(page.accessControls).not.to.be.null;",

--- a/postman/test/gio_documentation.json
+++ b/postman/test/gio_documentation.json
@@ -1943,6 +1943,7 @@
 									"var page = pm.response.json();",
 									"",
 									"pm.test(\"Should have excluded group\", function() {",
+									"    pm.expect(page.excluded_groups).to.have.members([pm.collectionVariables.get(\"created_reader_group_id\")]);",
 									"    pm.expect(page.visibility).to.eql(\"private\");",
 									"    pm.expect(page.excludedAccessControls).to.be.true;",
 									"    pm.expect(page.accessControls).not.to.be.null;",


### PR DESCRIPTION
fix gravitee-io/issues#4563