### PR TITLE
fix(api-review): check API has groups to avoid NPE

### DIFF
--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -3056,9 +3056,9 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             .collect(toSet());
 
         // find reviewers in group attached to the API
-        this.findById(apiId)
-            .getGroups()
-            .forEach(
+        final Set<String> groups = this.findById(apiId).getGroups();
+        if (groups != null && !groups.isEmpty()) {
+            groups.forEach(
                 group -> {
                     reviewerEmails.addAll(
                         roleService
@@ -3084,6 +3084,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                     );
                 }
             );
+        }
 
         return new ArrayList<>(reviewerEmails);
     }


### PR DESCRIPTION
When looking for reviewers of the API, so they can be sent an email when a review is asked, we were looking into the groups of the API but without checking if this API had groups.
So a NullPointerException happened when an API did not have any group.

Fixes gravitee-io/issues#5558