### PR TITLE
fix(url): check confirmlUrl is not null before sanitize it

### DIFF
--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -761,7 +761,9 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
     public UserEntity register(final NewExternalUserEntity newExternalUserEntity, final String confirmationPageUrl) {
         final GraviteeContext.ReferenceContext currentContext = GraviteeContext.getCurrentContext();
 
-        UrlSanitizerUtils.checkAllowed(confirmationPageUrl, portalWhitelist, true);
+        if (confirmationPageUrl != null) {
+            UrlSanitizerUtils.checkAllowed(confirmationPageUrl, portalWhitelist, true);
+        }
 
         checkUserRegistrationEnabled(currentContext);
         boolean autoRegistrationEnabled = isAutoRegistrationEnabled(currentContext);

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtils.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtils.java
@@ -20,7 +20,6 @@ import io.gravitee.rest.api.service.exceptions.UrlForbiddenException;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -71,7 +70,7 @@ public class UrlSanitizerUtils {
     public static void checkUriSyntax(String url) {
         try {
             new URI(url);
-        } catch (URISyntaxException e) {
+        } catch (Exception e) {
             throw new UrlForbiddenException();
         }
     }


### PR DESCRIPTION
Note: this PR has been opened on master to allow merge of 3.8.2 tag. The same fix must be backported on 3.5.x (and upper).

Closes gravitee-io/issues#5567