### PR TITLE
Add pre-expiration notification for subscriptions

### DIFF
--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/ApiKeyEntity.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/ApiKeyEntity.java
@@ -51,6 +51,11 @@ public class ApiKeyEntity {
 
     private boolean expired;
 
+    /**
+     * Number of days before the expiration of this api key when the last pre-expiration notification was sent
+     */
+    private Integer daysToExpirationOnLastNotification;
+
     public String getKey() {
         return key;
     }
@@ -137,6 +142,14 @@ public class ApiKeyEntity {
 
     public void setExpired(boolean expired) {
         this.expired = expired;
+    }
+
+    public Integer getDaysToExpirationOnLastNotification() {
+        return daysToExpirationOnLastNotification;
+    }
+
+    public void setDaysToExpirationOnLastNotification(Integer daysToExpirationOnLastNotification) {
+        this.daysToExpirationOnLastNotification = daysToExpirationOnLastNotification;
     }
 
     @Override

--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/SubscriptionEntity.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/SubscriptionEntity.java
@@ -77,6 +77,11 @@ public class SubscriptionEntity {
 
     private List<String> keys;
 
+    /**
+     * Number of days before the expiration of this subscription when the last pre-expiration notification was sent
+     */
+    private Integer daysToExpirationOnLastNotification;
+
     public String getId() {
         return id;
     }
@@ -219,6 +224,14 @@ public class SubscriptionEntity {
 
     public void setKeys(List<String> keys) {
         this.keys = keys;
+    }
+
+    public Integer getDaysToExpirationOnLastNotification() {
+        return daysToExpirationOnLastNotification;
+    }
+
+    public void setDaysToExpirationOnLastNotification(Integer daysToExpirationOnLastNotification) {
+        this.daysToExpirationOnLastNotification = daysToExpirationOnLastNotification;
     }
 
     @Override

--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/key/ApiKeyQuery.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/key/ApiKeyQuery.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.model.key;
+
+import java.util.Collection;
+import java.util.Objects;
+
+public class ApiKeyQuery {
+
+    private Collection<String> plans;
+
+    private long from, to;
+
+    private boolean includeRevoked;
+
+    private long expireAfter, expireBefore;
+
+    public Collection<String> getPlans() {
+        return plans;
+    }
+
+    public void setPlans(Collection<String> plans) {
+        this.plans = plans;
+    }
+
+    public long getFrom() {
+        return from;
+    }
+
+    public void setFrom(long from) {
+        this.from = from;
+    }
+
+    public long getTo() {
+        return to;
+    }
+
+    public void setTo(long to) {
+        this.to = to;
+    }
+
+    public boolean isIncludeRevoked() {
+        return includeRevoked;
+    }
+
+    public void setIncludeRevoked(boolean includeRevoked) {
+        this.includeRevoked = includeRevoked;
+    }
+
+    public long getExpireAfter() {
+        return expireAfter;
+    }
+
+    public void setExpireAfter(long expireAfter) {
+        this.expireAfter = expireAfter;
+    }
+
+    public long getExpireBefore() {
+        return expireBefore;
+    }
+
+    public void setExpireBefore(long expireBefore) {
+        this.expireBefore = expireBefore;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ApiKeyQuery that = (ApiKeyQuery) o;
+        return (
+            from == that.from &&
+            to == that.to &&
+            includeRevoked == that.includeRevoked &&
+            expireAfter == that.expireAfter &&
+            expireBefore == that.expireBefore &&
+            Objects.equals(plans, that.plans)
+        );
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(plans, from, to, includeRevoked, expireAfter, expireBefore);
+    }
+}

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiKeyService.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiKeyService.java
@@ -16,6 +16,9 @@
 package io.gravitee.rest.api.service;
 
 import io.gravitee.rest.api.model.ApiKeyEntity;
+import io.gravitee.rest.api.model.SubscriptionEntity;
+import io.gravitee.rest.api.model.key.ApiKeyQuery;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -43,5 +46,9 @@ public interface ApiKeyService {
 
     ApiKeyEntity update(ApiKeyEntity apiKeyEntity);
 
+    ApiKeyEntity updateDaysToExpirationOnLastNotification(String apiKey, Integer value);
+
     boolean exists(String apiKey);
+
+    Collection<ApiKeyEntity> search(ApiKeyQuery query);
 }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/SubscriptionService.java
@@ -48,6 +48,8 @@ public interface SubscriptionService {
 
     SubscriptionEntity update(UpdateSubscriptionEntity subscription);
 
+    SubscriptionEntity updateDaysToExpirationOnLastNotification(String subscriptionId, Integer value);
+
     SubscriptionEntity update(UpdateSubscriptionEntity subscription, String clientId);
 
     SubscriptionEntity process(ProcessSubscriptionEntity processSubscription, String userId);

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/builder/EmailNotificationBuilder.java
@@ -203,6 +203,11 @@ public class EmailNotificationBuilder {
             "passwordReset.html",
             "Password reset - ${user.displayName}"
         ),
+        TEMPLATES_FOR_ACTION_SUBSCRIPTION_PRE_EXPIRATION(
+            ActionHook.SUBSCRIPTION_PRE_EXPIRATION,
+            "subscriptionPreExpirationNotification.html",
+            "<#if apiKey??>API key of<#else>Subscription to</#if> ${api.name} will expire in ${expirationDelay} days!"
+        ),
         TEMPLATES_FOR_ACTION_GENERIC_MESSAGE(ActionHook.GENERIC_MESSAGE, "genericMessage.html", "${messageSubject}"),
         TEMPLATES_FOR_ALERT_CONSUMER_HTTP_STATUS(
             AlertHook.CONSUMER_HTTP_STATUS,

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/ActionHook.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/ActionHook.java
@@ -40,7 +40,12 @@ public enum ActionHook implements Hook {
     ),
     GENERIC_MESSAGE("Generic message", "Email sent when using the messaging service.", "SUPPORT", true),
     USER_GROUP_INVITATION("User group invitation", "Email sent when using the messaging service.", "USER"),
-    USER_PASSWORD_RESET("User password reset", "Email sent to a user which password has been reset.", "USER");
+    USER_PASSWORD_RESET("User password reset", "Email sent to a user which password has been reset.", "USER"),
+    SUBSCRIPTION_PRE_EXPIRATION(
+        "Subscription pre-expiration notification",
+        "Email sent to the subscriber and the primary owner of an application when a the subscription will expire after a specific duration.",
+        "SUBSCRIPTION"
+    );
 
     private String label;
     private String description;

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/NotificationParamsBuilder.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/notification/NotificationParamsBuilder.java
@@ -44,6 +44,7 @@ public class NotificationParamsBuilder {
     public static final String PARAM_TOKEN = "token";
     public static final String PARAM_REGISTRATION_URL = "registrationUrl";
     public static final String PARAM_EXPIRATION_DATE = "expirationDate";
+    public static final String PARAM_EXPIRATION_DELAY = "expirationDelay";
 
     public static final String REGISTRATION_PATH = "/#!/registration/confirm/";
     public static final String RESET_PASSWORD_PATH = "/#!/resetPassword/";

--- a/gravitee-rest-api-services/gravitee-rest-api-services-subscription-pre-expiration-notif/pom.xml
+++ b/gravitee-rest-api-services/gravitee-rest-api-services-subscription-pre-expiration-notif/pom.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.gravitee.rest.api.services</groupId>
+        <artifactId>gravitee-rest-api-services</artifactId>
+        <version>3.10.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>gravitee-rest-api-services-subscription-pre-expiration-notif</artifactId>
+    <name>Gravitee.io Rest APIs - Services - Subscription Pre Expiration Notif</name>
+
+    <dependencies>
+        <!-- Spring dependencies -->
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.3</version>
+                <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <descriptors>
+                        <descriptor>src/main/assembly/plugin-assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-plugin-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/gravitee-rest-api-services/gravitee-rest-api-services-subscription-pre-expiration-notif/src/main/assembly/plugin-assembly.xml
+++ b/gravitee-rest-api-services/gravitee-rest-api-services-subscription-pre-expiration-notif/src/main/assembly/plugin-assembly.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<assembly>
+	<id>plugin</id>
+	<formats>
+		<format>zip</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+
+	<!-- Include the main plugin Jar file -->
+	<files>
+		<file>
+			<source>${project.build.directory}/${project.build.finalName}.jar</source>
+		</file>
+	</files>
+
+	<!-- Finally include plugin dependencies -->
+	<dependencySets>
+		<dependencySet>
+			<outputDirectory>lib</outputDirectory>
+			<useProjectArtifact>false</useProjectArtifact>
+		</dependencySet>
+	</dependencySets>
+</assembly>

--- a/gravitee-rest-api-services/gravitee-rest-api-services-subscription-pre-expiration-notif/src/main/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationService.java
+++ b/gravitee-rest-api-services/gravitee-rest-api-services-subscription-pre-expiration-notif/src/main/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationService.java
@@ -1,0 +1,240 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.services.subscriptionpreexpirationnotif;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.gravitee.common.service.AbstractService;
+import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.key.ApiKeyQuery;
+import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
+import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.support.CronTrigger;
+
+public class ScheduledSubscriptionPreExpirationNotificationService extends AbstractService implements Runnable {
+
+    private final Logger logger = LoggerFactory.getLogger(ScheduledSubscriptionPreExpirationNotificationService.class);
+
+    @Autowired
+    private ApiService apiService;
+
+    @Autowired
+    private ApiKeyService apiKeyService;
+
+    @Autowired
+    private ApplicationService applicationService;
+
+    @Autowired
+    private EmailService emailService;
+
+    @Autowired
+    private PlanService planService;
+
+    @Autowired
+    private SubscriptionService subscriptionService;
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private TaskScheduler scheduler;
+
+    @Value("#{'${services.subscription.pre-expiration-notification-schedule:90,45,30}'.split(',')}")
+    private List<Integer> configPreExpirationNotificationSchedule;
+
+    @Value("${services.subscription.enabled:true}")
+    private boolean enabled;
+
+    // For debugging purposes you can change the trigger to "0 */1 * * * *" and the cronPeriodInMs to 60 * 1000
+    private final String cronTrigger = "0 0 */1 * * *";
+    private final int cronPeriodInMs = 60 * 60 * 1000;
+
+    private List<Integer> notificationDays;
+
+    private final AtomicLong counter = new AtomicLong(0);
+
+    @Override
+    protected String name() {
+        return "Subscription Pre Expiration Notification service";
+    }
+
+    @Override
+    protected void doStart() {
+        if (enabled) {
+            notificationDays = getCleanedNotificationDays(configPreExpirationNotificationSchedule);
+
+            logger.info("Subscription Pre Expiration Notification service has been initialized with cron [{}]", cronTrigger);
+            scheduler.schedule(this, new CronTrigger(cronTrigger));
+        } else {
+            logger.warn("Subscription Pre Expiration Notification service has been disabled");
+        }
+    }
+
+    @Override
+    public void run() {
+        logger.debug("Subscription Pre Expiration Notification #{} started at {}", counter.incrementAndGet(), Instant.now().toString());
+
+        Instant now = Instant.now();
+
+        notificationDays.forEach(
+            daysToExpiration -> {
+                Collection<SubscriptionEntity> subscriptionExpirationsToNotify = findSubscriptionExpirationsToNotify(now, daysToExpiration);
+                subscriptionExpirationsToNotify
+                    .stream()
+                    .filter(
+                        // Remove the ones for which an email has already been sent (could happen in case of restart or concurrent processing with multiple instance of APIM)
+                        subscription ->
+                            subscription.getDaysToExpirationOnLastNotification() == null ||
+                            subscription.getDaysToExpirationOnLastNotification() > daysToExpiration
+                    )
+                    .forEach(subscription -> notifySubscription(daysToExpiration, subscription));
+
+                List<String> notifiedSubscriptionIds = subscriptionExpirationsToNotify
+                    .stream()
+                    .map(SubscriptionEntity::getId)
+                    .collect(Collectors.toList());
+
+                Collection<ApiKeyEntity> apiKeyExpirationsToNotify = findApiKeyExpirationsToNotify(now, daysToExpiration);
+                apiKeyExpirationsToNotify
+                    .stream()
+                    // Remove the ones for which an email has already been sent (could happen in case of restart or concurrent processing with multiple instance of APIM)
+                    .filter(
+                        apiKey ->
+                            apiKey.getDaysToExpirationOnLastNotification() == null ||
+                            apiKey.getDaysToExpirationOnLastNotification() > daysToExpiration
+                    )
+                    // Remove the ones related to a subscription for which an email was just sent
+                    .filter(apiKey -> !notifiedSubscriptionIds.contains(apiKey.getSubscription()))
+                    .forEach(apiKey -> notificationApiKeyExpiration(daysToExpiration, apiKey));
+            }
+        );
+
+        logger.debug("Subscription Pre Expiration Notification #{} ended at {}", counter.get(), Instant.now().toString());
+    }
+
+    private ApiKeyEntity notificationApiKeyExpiration(Integer daysToExpiration, ApiKeyEntity apiKey) {
+        SubscriptionEntity subscription = subscriptionService.findById(apiKey.getSubscription());
+        ApiEntity api = apiService.findById(subscription.getApi());
+        PlanEntity plan = planService.findById(subscription.getPlan());
+        ApplicationEntity application = applicationService.findById(subscription.getApplication());
+
+        findEmailsToNotify(subscription, application)
+            .forEach(email -> this.sendEmail(email, daysToExpiration, api, plan, application, apiKey));
+
+        return apiKeyService.updateDaysToExpirationOnLastNotification(apiKey.getKey(), daysToExpiration);
+    }
+
+    private SubscriptionEntity notifySubscription(Integer daysToExpiration, SubscriptionEntity subscription) {
+        ApiEntity api = apiService.findById(subscription.getApi());
+        PlanEntity plan = planService.findById(subscription.getPlan());
+
+        ApplicationEntity application = applicationService.findById(subscription.getApplication());
+
+        findEmailsToNotify(subscription, application)
+            .forEach(email -> this.sendEmail(email, daysToExpiration, api, plan, application, null));
+
+        return subscriptionService.updateDaysToExpirationOnLastNotification(subscription.getId(), daysToExpiration);
+    }
+
+    @VisibleForTesting
+    List<Integer> getCleanedNotificationDays(List<Integer> inputDays) {
+        int min = 1;
+        int max = 366;
+
+        Predicate<Integer> isDayValid = day -> min <= day && day <= max;
+
+        List<Integer> invalidValues = inputDays.stream().filter(day -> !isDayValid.test(day)).collect(Collectors.toList());
+
+        if (!invalidValues.isEmpty()) {
+            logger.warn(
+                "The configuration key `services.subscription.pre-expiration-notification-schedule` contains some invalid values: {}. Values should be between {} and {} (days).",
+                invalidValues.stream().map(Object::toString).collect(Collectors.joining(", ")),
+                min,
+                max
+            );
+        }
+
+        return inputDays.stream().filter(isDayValid).sorted(Comparator.reverseOrder()).collect(Collectors.toList());
+    }
+
+    @VisibleForTesting
+    Collection<SubscriptionEntity> findSubscriptionExpirationsToNotify(Instant now, Integer daysToExpiration) {
+        long expirationStartingTime = now.plus(Duration.ofDays((long) daysToExpiration)).getEpochSecond() * 1000;
+
+        SubscriptionQuery query = new SubscriptionQuery();
+        query.setStatuses(Arrays.asList(SubscriptionStatus.ACCEPTED, SubscriptionStatus.PAUSED));
+        query.setEndingAtAfter(expirationStartingTime);
+        query.setEndingAtBefore(expirationStartingTime + cronPeriodInMs);
+
+        return subscriptionService.search(query);
+    }
+
+    @VisibleForTesting
+    Collection<ApiKeyEntity> findApiKeyExpirationsToNotify(Instant now, Integer daysToExpiration) {
+        long expirationStartingTime = now.plus(Duration.ofDays((long) daysToExpiration)).getEpochSecond() * 1000;
+
+        ApiKeyQuery query = new ApiKeyQuery();
+        query.setIncludeRevoked(false);
+        query.setExpireAfter(expirationStartingTime);
+        query.setExpireBefore(expirationStartingTime + cronPeriodInMs);
+
+        return apiKeyService.search(query);
+    }
+
+    @VisibleForTesting
+    Set<String> findEmailsToNotify(SubscriptionEntity subscription, ApplicationEntity application) {
+        Set<String> emails = new HashSet<>();
+        emails.add(userService.findById(subscription.getSubscribedBy()).getEmail());
+        emails.add(application.getPrimaryOwner().getEmail());
+
+        // Email can be null, in that case we can't send a notification so just remove it
+        return emails.stream().filter(Objects::nonNull).collect(Collectors.toSet());
+    }
+
+    @VisibleForTesting
+    void sendEmail(String subscriberEmail, int day, ApiEntity api, PlanEntity plan, ApplicationEntity application, ApiKeyEntity apiKey) {
+        GraviteeContext.ReferenceContext context = new GraviteeContext.ReferenceContext(
+            api.getReferenceId(),
+            GraviteeContext.ReferenceContextType.ENVIRONMENT
+        );
+
+        EmailNotification emailNotification = new EmailNotificationBuilder()
+            .to(subscriberEmail)
+            .template(EmailNotificationBuilder.EmailTemplate.TEMPLATES_FOR_ACTION_SUBSCRIPTION_PRE_EXPIRATION)
+            .param(NotificationParamsBuilder.PARAM_EXPIRATION_DELAY, day)
+            .param(NotificationParamsBuilder.PARAM_PLAN, plan)
+            .param(NotificationParamsBuilder.PARAM_API, api)
+            .param(NotificationParamsBuilder.PARAM_APPLICATION, application)
+            .param(NotificationParamsBuilder.PARAM_API_KEY, apiKey)
+            .build();
+
+        emailService.sendAsyncEmailNotification(emailNotification, context);
+    }
+}

--- a/gravitee-rest-api-services/gravitee-rest-api-services-subscription-pre-expiration-notif/src/main/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/spring/SubscriptionPreExpirationNotificationConfiguration.java
+++ b/gravitee-rest-api-services/gravitee-rest-api-services-subscription-pre-expiration-notif/src/main/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/spring/SubscriptionPreExpirationNotificationConfiguration.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.services.subscriptionpreexpirationnotif.spring;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SubscriptionPreExpirationNotificationConfiguration {
+
+    @Bean
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setThreadNamePrefix("subscription-pre-expiration-notification-");
+        return scheduler;
+    }
+}

--- a/gravitee-rest-api-services/gravitee-rest-api-services-subscription-pre-expiration-notif/src/main/resources/plugin.properties
+++ b/gravitee-rest-api-services/gravitee-rest-api-services-subscription-pre-expiration-notif/src/main/resources/plugin.properties
@@ -1,0 +1,6 @@
+id=subscription-expiration-notifier
+name=${project.name}
+version=${project.version}
+description=${project.description}
+class=io.gravitee.rest.api.services.subscriptionpreexpirationnotif.ScheduledSubscriptionPreExpirationNotificationService
+type=service

--- a/gravitee-rest-api-services/gravitee-rest-api-services-subscription-pre-expiration-notif/src/test/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationServiceTest.java
+++ b/gravitee-rest-api-services/gravitee-rest-api-services-subscription-pre-expiration-notif/src/test/java/io/gravitee/rest/api/services/subscriptionpreexpirationnotif/ScheduledSubscriptionPreExpirationNotificationServiceTest.java
@@ -1,0 +1,195 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.services.subscriptionpreexpirationnotif;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.model.key.ApiKeyQuery;
+import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
+import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
+import io.gravitee.rest.api.service.common.GraviteeContext;
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ScheduledSubscriptionPreExpirationNotificationServiceTest {
+
+    @InjectMocks
+    ScheduledSubscriptionPreExpirationNotificationService service = new ScheduledSubscriptionPreExpirationNotificationService();
+
+    @Mock
+    UserService userService;
+
+    @Mock
+    SubscriptionService subscriptionService;
+
+    @Mock
+    ApiKeyService apiKeyService;
+
+    @Mock
+    EmailService emailService;
+
+    @Test
+    public void shouldCleanNotificationDays() {
+        List<Integer> inputNotificationDays = Arrays.asList(-1, 150, 75, 10, 30, 400, 45);
+        List<Integer> cleanedNotificationDays = service.getCleanedNotificationDays(inputNotificationDays);
+
+        assertEquals(Arrays.asList(150, 75, 45, 30, 10), cleanedNotificationDays);
+    }
+
+    @Test
+    public void shouldFindSubscriptionExpirationsToNotify() {
+        Instant now = Instant.ofEpochMilli(1469022010000L);
+        Integer daysBeforeNotification = 10;
+
+        SubscriptionEntity subscription = mock(SubscriptionEntity.class);
+
+        when(subscriptionService.search(any(SubscriptionQuery.class))).thenReturn(Collections.singletonList(subscription));
+
+        Collection<SubscriptionEntity> subscriptionsToNotify = service.findSubscriptionExpirationsToNotify(now, daysBeforeNotification);
+
+        assertEquals(Collections.singletonList(subscription), subscriptionsToNotify);
+
+        verify(subscriptionService, times(1))
+            .search(
+                argThat(
+                    subscriptionQuery ->
+                        Arrays.asList(SubscriptionStatus.ACCEPTED, SubscriptionStatus.PAUSED).equals(subscriptionQuery.getStatuses()) &&
+                        // 1469886010000 -> now + 10 days
+                        subscriptionQuery.getEndingAtAfter() ==
+                        1469886010000L &&
+                        // 1469889610000 -> now + 10 days + 1h (cron period)
+                        subscriptionQuery.getEndingAtBefore() ==
+                        1469889610000L
+                )
+            );
+    }
+
+    @Test
+    public void shouldFindEmailToNotifyWithDifferentSubscriberAndPrimaryOwner() {
+        String subscriberId = UUID.randomUUID().toString();
+        UserEntity subscriber = mock(UserEntity.class);
+        when(subscriber.getEmail()).thenReturn("subscriber@gravitee.io");
+
+        SubscriptionEntity subscription = mock(SubscriptionEntity.class);
+        when(subscription.getSubscribedBy()).thenReturn(subscriberId);
+
+        when(userService.findById(subscriberId)).thenReturn(subscriber);
+
+        PrimaryOwnerEntity primaryOwner = mock(PrimaryOwnerEntity.class);
+        when(primaryOwner.getEmail()).thenReturn("primary_owner@gravitee.io");
+
+        ApplicationEntity application = mock(ApplicationEntity.class);
+        when(application.getPrimaryOwner()).thenReturn(primaryOwner);
+
+        Collection<String> usersToNotify = service.findEmailsToNotify(subscription, application);
+
+        Set<String> expected = new HashSet<>();
+        expected.add("subscriber@gravitee.io");
+        expected.add("primary_owner@gravitee.io");
+        assertEquals(expected, usersToNotify);
+    }
+
+    @Test
+    public void shouldFindEmailToNotifyWithSameSubscriberAndPrimaryOwner() {
+        String subscriberId = UUID.randomUUID().toString();
+        UserEntity subscriber = mock(UserEntity.class);
+        when(subscriber.getEmail()).thenReturn("primary_owner@gravitee.io");
+
+        SubscriptionEntity subscription = mock(SubscriptionEntity.class);
+        when(subscription.getSubscribedBy()).thenReturn(subscriberId);
+
+        when(userService.findById(subscriberId)).thenReturn(subscriber);
+
+        PrimaryOwnerEntity primaryOwner = mock(PrimaryOwnerEntity.class);
+        when(primaryOwner.getEmail()).thenReturn("primary_owner@gravitee.io");
+
+        ApplicationEntity application = mock(ApplicationEntity.class);
+        when(application.getPrimaryOwner()).thenReturn(primaryOwner);
+
+        Collection<String> usersToNotify = service.findEmailsToNotify(subscription, application);
+
+        Set<String> expected = new HashSet<>();
+        expected.add("primary_owner@gravitee.io");
+        assertEquals(expected, usersToNotify);
+    }
+
+    @Test
+    public void shouldSendEmail() {
+        int day = 30;
+        String subscriberEmail = "subscriber@gravitee.io";
+
+        ApiEntity api = mock(ApiEntity.class);
+        // here api.getReferenceId() = environmentId
+        when(api.getReferenceId()).thenReturn(UUID.randomUUID().toString());
+
+        PlanEntity plan = mock(PlanEntity.class);
+        ApplicationEntity application = mock(ApplicationEntity.class);
+        ApiKeyEntity apiKey = mock(ApiKeyEntity.class);
+
+        service.sendEmail(subscriberEmail, day, api, plan, application, apiKey);
+
+        EmailNotification emailNotification = new EmailNotificationBuilder()
+            .to(subscriberEmail)
+            .template(EmailNotificationBuilder.EmailTemplate.TEMPLATES_FOR_ACTION_SUBSCRIPTION_PRE_EXPIRATION)
+            .param("expirationDelay", day)
+            .param("api", api)
+            .param("plan", plan)
+            .param("application", application)
+            .param("apiKey", apiKey)
+            .build();
+
+        verify(emailService, times(1)).sendAsyncEmailNotification(eq(emailNotification), any(GraviteeContext.ReferenceContext.class));
+    }
+
+    @Test
+    public void shouldFindApiKeyExpirationsToNotify() {
+        Instant now = Instant.ofEpochMilli(1469022010000L);
+        Integer daysBeforeNotification = 10;
+
+        ApiKeyEntity apiKey = mock(ApiKeyEntity.class);
+
+        when(apiKeyService.search(any(ApiKeyQuery.class))).thenReturn(Collections.singletonList(apiKey));
+
+        Collection<ApiKeyEntity> apiKeysToNotify = service.findApiKeyExpirationsToNotify(now, daysBeforeNotification);
+
+        assertEquals(Collections.singletonList(apiKey), apiKeysToNotify);
+
+        verify(apiKeyService, times(1))
+            .search(
+                argThat(
+                    apiKeyQuery ->
+                        !apiKeyQuery.isIncludeRevoked() &&
+                        // 1469886010000 -> now + 10 days
+                        apiKeyQuery.getExpireAfter() ==
+                        1469886010000L &&
+                        // 1469889610000 -> now + 10 days + 1h (cron period)
+                        apiKeyQuery.getExpireBefore() ==
+                        1469889610000L
+                )
+            );
+    }
+}

--- a/gravitee-rest-api-services/pom.xml
+++ b/gravitee-rest-api-services/pom.xml
@@ -40,6 +40,7 @@
         <module>gravitee-rest-api-services-search-indexer</module>
         <module>gravitee-rest-api-services-v3-upgrader</module>
         <module>gravitee-rest-api-services-auto-fetch</module>
+        <module>gravitee-rest-api-services-subscription-pre-expiration-notif</module>
     </modules>
 
     <dependencyManagement>

--- a/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
+++ b/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/src/main/resources/config/gravitee.yml
@@ -170,6 +170,12 @@ services:
     enabled: true
     cron: "0 */5 * * * *"
 
+  # Subscription service
+  subscription:
+    enabled: true
+    #  Pre-expiration notification, number of days before the expiration an email should be send to subscriber and primary owner
+    pre-expiration-notification-schedule: 90,45,30
+
 
 # Analytics repository is used to store all reporting, metrics, health-checks stored by gateway instances
 # This is the default configuration using Elasticsearch

--- a/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/src/main/resources/templates/subscriptionPreExpirationNotification.html
+++ b/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/src/main/resources/templates/subscriptionPreExpirationNotification.html
@@ -1,0 +1,11 @@
+<html>
+    <body style="text-align: center">
+        <header><#include "header.html" /></header>
+        <div style="margin-top: 50px; color: #424e5a">
+            <h3>Hi,</h3>
+            <p>
+                <#if apiKey??> The API key <code>${apiKey.key}</code> related to plan<#else>The subscription to plan</#if> <b>${plan.name}</b> for API <b>${api.name}</b> and application <b>${application.name}</b> will expire in ${expirationDelay} days.
+            </p>
+        </div>
+    </body>
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <gravitee-common.version>1.20.0</gravitee-common.version>
         <gravitee-definition.version>1.28.0</gravitee-definition.version>
         <gravitee-plugin.version>1.16.0</gravitee-plugin.version>
-        <gravitee-repository.version>3.9.0</gravitee-repository.version>
+        <gravitee-repository.version>3.10.0-SNAPSHOT</gravitee-repository.version>
         <gravitee-gateway-api.version>1.20.1</gravitee-gateway-api.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-expression-language.version>1.5.0</gravitee-expression-language.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/3887

**Description**

Add pre-expiration notification for subscriptions:
 - Add a scheduled service running every hour, it computes the subscription matching the expiration criteria and sends an email 
 - Add a custom template for this email notification
 - 

**Additional context**

In progress
