### PR TITLE
fix: test plan status before accepting updates

### DIFF
--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -244,7 +244,7 @@ public class ApiResource extends AbstractResource {
             apiToUpdate.getProxy().setVirtualHosts(currentApi.getProxy().getVirtualHosts());
         }
 
-        final ApiEntity updatedApi = apiService.update(api, apiToUpdate);
+        final ApiEntity updatedApi = apiService.update(api, apiToUpdate, true);
         setPictures(updatedApi);
 
         return Response

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceTest.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiResourceTest.java
@@ -85,7 +85,7 @@ public class ApiResourceTest extends AbstractResourceTest {
         proxy.setVirtualHosts(Collections.singletonList(new VirtualHost("/test")));
         updateApiEntity.setProxy(proxy);
         updateApiEntity.setLifecycleState(ApiLifecycleState.CREATED);
-        doReturn(mockApi).when(apiService).update(eq(API), any());
+        doReturn(mockApi).when(apiService).update(eq(API), any(), eq(true));
     }
 
     @Test

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiService.java
@@ -57,6 +57,8 @@ public interface ApiService {
     ApiEntity createFromSwagger(SwaggerApiEntity api, String userId, ImportSwaggerDescriptorEntity swaggerDescriptor);
 
     ApiEntity update(String apiId, UpdateApiEntity api);
+    ApiEntity update(String apiId, UpdateApiEntity api, boolean checkPlans);
+
     ApiEntity updateFromSwagger(String apiId, SwaggerApiEntity swaggerApiEntity, ImportSwaggerDescriptorEntity swaggerDescriptor);
 
     void delete(String apiId);


### PR DESCRIPTION
fixes gravitee-io/issues#5718

**Issue**

https://github.com/gravitee-io/issues/issues/5718

**Description**

In this PR we want to prevent the update of plan into the API definition to avoid inconsistency between the UI and the information deploy into the gateway.

**Additional context**

<!-- Add any other context about the PR here -->
<!-- It can be links to other PRs or docs or drawing -->
<!-- Or reproduction steps in case of bug fix -->

