### PR TITLE
fix: add auto-fetch plugin into distribution bundle

### DIFF
--- a/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/pom.xml
+++ b/gravitee-rest-api-standalone/gravitee-rest-api-standalone-distribution/pom.xml
@@ -139,6 +139,14 @@
 			<scope>runtime</scope>
 			<type>zip</type>
 		</dependency>
+
+		<dependency>
+			<groupId>io.gravitee.rest.api.services</groupId>
+			<artifactId>gravitee-rest-api-services-auto-fetch</artifactId>
+			<version>${project.version}</version>
+			<scope>runtime</scope>
+			<type>zip</type>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -185,6 +193,12 @@
 								<artifactItem>
 									<groupId>io.gravitee.rest.api.services</groupId>
 									<artifactId>gravitee-rest-api-services-search-indexer</artifactId>
+									<version>${project.version}</version>
+									<type>zip</type>
+								</artifactItem>
+								<artifactItem>
+									<groupId>io.gravitee.rest.api.services</groupId>
+									<artifactId>gravitee-rest-api-services-auto-fetch</artifactId>
 									<version>${project.version}</version>
 									<type>zip</type>
 								</artifactItem>


### PR DESCRIPTION
fixes gravitee-io/issues#5699

**Issue**

https://github.com/gravitee-io/issues/issues/5699

**Description**

AutoFetch workes but the plugin isn't included into the APIM bundle

