### PR TITLE
feat(management): manage AsciiDoc documentation pages

### DIFF
--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/PageType.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/PageType.java
@@ -29,6 +29,7 @@ import java.util.List;
  *
  */
 public enum PageType {
+    ASCIIDOC(unmodifiableList(asList("adoc")), 200),
     MARKDOWN(unmodifiableList(asList("md", "markdown")), 200),
     MARKDOWN_TEMPLATE(emptyList(), 200),
     SWAGGER(unmodifiableList(asList("json", "yaml", "yml")), 200),

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/resources/openapi.yaml
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/resources/openapi.yaml
@@ -3543,6 +3543,7 @@ components:
           description: Type of documentation.
           type: string
           enum:
+            - ASCIIDOC
             - SWAGGER
             - MARKDOWN
             - FOLDER

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/Api3_7VersionSerializer.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/Api3_7VersionSerializer.java
@@ -30,9 +30,9 @@ import java.util.stream.Collectors;
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public class ApiDefaultSerializer extends ApiSerializer {
+public class Api3_7VersionSerializer extends ApiSerializer {
 
-    public ApiDefaultSerializer() {
+    public Api3_7VersionSerializer() {
         super(ApiEntity.class);
     }
 
@@ -63,6 +63,22 @@ public class ApiDefaultSerializer extends ApiSerializer {
 
         // proxy part
         if (apiEntity.getProxy() != null) {
+            Set<EndpointGroup> groups = apiEntity.getProxy().getGroups();
+            if (groups != null) {
+                groups.forEach(
+                    grp -> {
+                        if (grp.getEndpoints() != null) {
+                            grp.setEndpoints(
+                                grp
+                                    .getEndpoints()
+                                    .stream()
+                                    .filter(endpoint -> endpoint.getType() == EndpointType.HTTP)
+                                    .collect(Collectors.toSet())
+                            );
+                        }
+                    }
+                );
+            }
             jsonGenerator.writeObjectField("proxy", apiEntity.getProxy());
         }
 
@@ -89,6 +105,6 @@ public class ApiDefaultSerializer extends ApiSerializer {
 
     @Override
     public Version version() {
-        return Version.DEFAULT;
+        return Version.V_3_7;
     }
 }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiCompositeSerializer.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiCompositeSerializer.java
@@ -68,6 +68,7 @@ public class ApiCompositeSerializer extends ApiSerializer implements Initializin
         addSerializer(new Api1_20VersionSerializer());
         addSerializer(new Api1_25VersionSerializer());
         addSerializer(new Api3_0VersionSerializer());
+        addSerializer(new Api3_7VersionSerializer());
     }
 
     private void addSerializer(ApiSerializer apiSerializer) {

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
@@ -177,6 +177,7 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
                 List<PageEntity> pages = applicationContext
                     .getBean(PageService.class)
                     .search(new PageQuery.Builder().api(apiEntity.getId()).build(), true);
+
                 if (this.version().getVersion().startsWith("1.")) {
                     pages =
                         pages
@@ -185,8 +186,26 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
                                 pageEntity ->
                                     !pageEntity.getType().equals(PageType.LINK.name()) &&
                                     !pageEntity.getType().equals(PageType.TRANSLATION.name()) &&
-                                    !pageEntity.getType().equals(PageType.SYSTEM_FOLDER.name())
+                                    !pageEntity.getType().equals(PageType.SYSTEM_FOLDER.name()) &&
+                                    !pageEntity.getType().equals(PageType.MARKDOWN_TEMPLATE.name()) &&
+                                    !pageEntity.getType().equals(PageType.ASCIIDOC.name())
                             )
+                            .collect(Collectors.toList());
+                } else if (this.version().getVersion().equals("3.0")) {
+                    pages =
+                        pages
+                            .stream()
+                            .filter(
+                                pageEntity ->
+                                    !pageEntity.getType().equals(PageType.MARKDOWN_TEMPLATE.name()) &&
+                                    !pageEntity.getType().equals(PageType.ASCIIDOC.name())
+                            )
+                            .collect(Collectors.toList());
+                } else if (this.version().getVersion().equals("3.7")) {
+                    pages =
+                        pages
+                            .stream()
+                            .filter(pageEntity -> !pageEntity.getType().equals(PageType.ASCIIDOC.name()))
                             .collect(Collectors.toList());
                 }
                 jsonGenerator.writeObjectField("pages", pages == null ? Collections.emptyList() : pages);
@@ -216,11 +235,12 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
     }
 
     public enum Version {
-        DEFAULT("default"),
+        DEFAULT("default"), // AsciiDoc in 3.10
         V_1_15("1.15"),
         V_1_20("1.20"),
         V_1_25("1.25"),
-        V_3_0("3.0");
+        V_3_0("3.0"), // System folders & Links & translations
+        V_3_7("3.7"); // Markdown template
 
         private final String version;
 

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_ExportAsJsonTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_ExportAsJsonTest.java
@@ -50,6 +50,11 @@ public class ApiService_ExportAsJsonTest extends ApiService_ExportAsJsonTestSetu
     }
 
     @Test
+    public void shouldConvertAsJsonForExport_3_7() throws TechnicalException, IOException {
+        shouldConvertAsJsonForExport(ApiSerializer.Version.V_3_7, "3_7");
+    }
+
+    @Test
     public void shouldConvertAsJsonForExport_3_0() throws TechnicalException, IOException {
         shouldConvertAsJsonForExport(ApiSerializer.Version.V_3_0, "3_0");
     }
@@ -72,6 +77,11 @@ public class ApiService_ExportAsJsonTest extends ApiService_ExportAsJsonTestSetu
     @Test
     public void shouldConvertAsJsonWithoutMembers() throws IOException {
         shouldConvertAsJsonWithoutMembers(ApiSerializer.Version.DEFAULT, null);
+    }
+
+    @Test
+    public void shouldConvertAsJsonWithoutMembers_3_7() throws IOException {
+        shouldConvertAsJsonWithoutMembers(ApiSerializer.Version.V_3_7, "3_7");
     }
 
     @Test
@@ -100,6 +110,11 @@ public class ApiService_ExportAsJsonTest extends ApiService_ExportAsJsonTestSetu
     }
 
     @Test
+    public void shouldConvertAsJsonWithoutPages_3_7() throws IOException {
+        shouldConvertAsJsonWithoutPages(ApiSerializer.Version.V_3_7, "3_7");
+    }
+
+    @Test
     public void shouldConvertAsJsonWithoutPages_3_0() throws IOException {
         shouldConvertAsJsonWithoutPages(ApiSerializer.Version.V_3_0, "3_0");
     }
@@ -122,6 +137,11 @@ public class ApiService_ExportAsJsonTest extends ApiService_ExportAsJsonTestSetu
     @Test
     public void shouldConvertAsJsonWithoutPlans() throws IOException {
         shouldConvertAsJsonWithoutPlans(ApiSerializer.Version.DEFAULT, null);
+    }
+
+    @Test
+    public void shouldConvertAsJsonWithoutPlans_3_7() throws IOException {
+        shouldConvertAsJsonWithoutPlans(ApiSerializer.Version.V_3_7, "3_7");
     }
 
     @Test
@@ -208,6 +228,11 @@ public class ApiService_ExportAsJsonTest extends ApiService_ExportAsJsonTestSetu
     @Test
     public void shouldConvertAsJsonWithoutMetadata() throws IOException {
         shouldConvertAsJsonWithoutMetadata(ApiSerializer.Version.DEFAULT, null);
+    }
+
+    @Test
+    public void shouldConvertAsJsonWithoutMetadata_3_7() throws IOException {
+        shouldConvertAsJsonWithoutMetadata(ApiSerializer.Version.V_3_7, "3_7");
     }
 
     @Test

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_ExportAsJsonTestSetup.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_ExportAsJsonTestSetup.java
@@ -137,6 +137,9 @@ public class ApiService_ExportAsJsonTestSetup {
         //V_3_0
         ApiSerializer apiPrior30VersionSerializer = new Api3_0VersionSerializer();
         apiPrior30VersionSerializer.setApplicationContext(applicationContext);
+        //V_3_7
+        ApiSerializer apiPrior37VersionSerializer = new Api3_7VersionSerializer();
+        apiPrior37VersionSerializer.setApplicationContext(applicationContext);
 
         apiCompositeSerializer.setSerializers(
             Arrays.asList(
@@ -144,7 +147,8 @@ public class ApiService_ExportAsJsonTestSetup {
                 apiPrior115VersionSerializer,
                 apiPrior120VersionSerializer,
                 apiPrior125VersionSerializer,
-                apiPrior30VersionSerializer
+                apiPrior30VersionSerializer,
+                apiPrior37VersionSerializer
             )
         );
         SimpleModule module = new SimpleModule();
@@ -163,19 +167,57 @@ public class ApiService_ExportAsJsonTestSetup {
         api.setEnvironmentId("DEFAULT");
 
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
-        PageEntity page = new PageEntity();
-        page.setName("My Title");
-        page.setOrder(1);
-        page.setType(PageType.MARKDOWN.toString());
-        page.setContent("Read the doc");
-        page.setVisibility(Visibility.PUBLIC);
+        PageEntity folder = new PageEntity();
+        folder.setName("My Folder");
+        folder.setOrder(1);
+        folder.setType(PageType.FOLDER.toString());
+        folder.setVisibility(Visibility.PUBLIC);
+        PageEntity markdownPage = new PageEntity();
+        markdownPage.setName("My Title");
+        markdownPage.setOrder(1);
+        markdownPage.setType(PageType.MARKDOWN.toString());
+        markdownPage.setContent("Read the doc");
+        markdownPage.setVisibility(Visibility.PUBLIC);
         PageEntity asideFolder = new PageEntity();
         asideFolder.setName("Aside");
         asideFolder.setOrder(1);
         asideFolder.setPublished(true);
         asideFolder.setType(PageType.SYSTEM_FOLDER.toString());
         asideFolder.setVisibility(Visibility.PUBLIC);
-        when(pageService.search(any(), eq(true))).thenReturn(Arrays.asList(page, asideFolder));
+        PageEntity swaggerPage = new PageEntity();
+        swaggerPage.setName("My Swagger");
+        swaggerPage.setOrder(1);
+        swaggerPage.setType(PageType.SWAGGER.toString());
+        swaggerPage.setContent("Read the doc");
+        swaggerPage.setVisibility(Visibility.PUBLIC);
+        PageEntity linkPage = new PageEntity();
+        linkPage.setName("My Link");
+        linkPage.setOrder(1);
+        linkPage.setType(PageType.LINK.toString());
+        linkPage.setContent("Read the doc");
+        linkPage.setVisibility(Visibility.PUBLIC);
+        PageEntity translationPage = new PageEntity();
+        translationPage.setName("My Translation");
+        translationPage.setOrder(1);
+        translationPage.setType(PageType.TRANSLATION.toString());
+        translationPage.setContent("Lire la documentation");
+        translationPage.setVisibility(Visibility.PUBLIC);
+        PageEntity markdownTemplatePage = new PageEntity();
+        markdownTemplatePage.setName("My Template");
+        markdownTemplatePage.setOrder(1);
+        markdownTemplatePage.setType(PageType.MARKDOWN_TEMPLATE.toString());
+        markdownTemplatePage.setContent("Read the doc");
+        markdownTemplatePage.setVisibility(Visibility.PUBLIC);
+        PageEntity asciidocPage = new PageEntity();
+        asciidocPage.setName("My asciidoc");
+        asciidocPage.setOrder(1);
+        asciidocPage.setType(PageType.ASCIIDOC.toString());
+        asciidocPage.setContent("Read the asciidoc");
+        asciidocPage.setVisibility(Visibility.PUBLIC);
+        when(pageService.search(any(), eq(true)))
+            .thenReturn(
+                Arrays.asList(folder, markdownPage, swaggerPage, asideFolder, linkPage, translationPage, markdownTemplatePage, asciidocPage)
+            );
 
         RoleEntity poRole = new RoleEntity();
         poRole.setName("PRIMARY_OWNER");

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_gRPC_ExportAsJsonTestSetup.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiService_gRPC_ExportAsJsonTestSetup.java
@@ -138,6 +138,9 @@ public class ApiService_gRPC_ExportAsJsonTestSetup {
         //V_3_0
         ApiSerializer apiPrior30VersionSerializer = new Api3_0VersionSerializer();
         apiPrior30VersionSerializer.setApplicationContext(applicationContext);
+        //V_3_7
+        ApiSerializer apiPrior37VersionSerializer = new Api3_7VersionSerializer();
+        apiPrior37VersionSerializer.setApplicationContext(applicationContext);
 
         apiCompositeSerializer.setSerializers(
             Arrays.asList(
@@ -145,7 +148,8 @@ public class ApiService_gRPC_ExportAsJsonTestSetup {
                 apiPrior115VersionSerializer,
                 apiPrior120VersionSerializer,
                 apiPrior125VersionSerializer,
-                apiPrior30VersionSerializer
+                apiPrior30VersionSerializer,
+                apiPrior37VersionSerializer
             )
         );
         SimpleModule module = new SimpleModule();
@@ -164,19 +168,57 @@ public class ApiService_gRPC_ExportAsJsonTestSetup {
         api.setEnvironmentId("DEFAULT");
 
         when(apiRepository.findById(API_ID)).thenReturn(Optional.of(api));
-        PageEntity page = new PageEntity();
-        page.setName("My Title");
-        page.setOrder(1);
-        page.setType(PageType.MARKDOWN.toString());
-        page.setContent("Read the doc");
-        page.setVisibility(Visibility.PUBLIC);
+        PageEntity folder = new PageEntity();
+        folder.setName("My Folder");
+        folder.setOrder(1);
+        folder.setType(PageType.FOLDER.toString());
+        folder.setVisibility(Visibility.PUBLIC);
+        PageEntity markdownPage = new PageEntity();
+        markdownPage.setName("My Title");
+        markdownPage.setOrder(1);
+        markdownPage.setType(PageType.MARKDOWN.toString());
+        markdownPage.setContent("Read the doc");
+        markdownPage.setVisibility(Visibility.PUBLIC);
         PageEntity asideFolder = new PageEntity();
         asideFolder.setName("Aside");
         asideFolder.setOrder(1);
         asideFolder.setPublished(true);
         asideFolder.setType(PageType.SYSTEM_FOLDER.toString());
         asideFolder.setVisibility(Visibility.PUBLIC);
-        when(pageService.search(any(), eq(true))).thenReturn(Arrays.asList(page, asideFolder));
+        PageEntity swaggerPage = new PageEntity();
+        swaggerPage.setName("My Swagger");
+        swaggerPage.setOrder(1);
+        swaggerPage.setType(PageType.SWAGGER.toString());
+        swaggerPage.setContent("Read the doc");
+        swaggerPage.setVisibility(Visibility.PUBLIC);
+        PageEntity linkPage = new PageEntity();
+        linkPage.setName("My Link");
+        linkPage.setOrder(1);
+        linkPage.setType(PageType.LINK.toString());
+        linkPage.setContent("Read the doc");
+        linkPage.setVisibility(Visibility.PUBLIC);
+        PageEntity translationPage = new PageEntity();
+        translationPage.setName("My Translation");
+        translationPage.setOrder(1);
+        translationPage.setType(PageType.TRANSLATION.toString());
+        translationPage.setContent("Lire la documentation");
+        translationPage.setVisibility(Visibility.PUBLIC);
+        PageEntity markdownTemplatePage = new PageEntity();
+        markdownTemplatePage.setName("My Template");
+        markdownTemplatePage.setOrder(1);
+        markdownTemplatePage.setType(PageType.MARKDOWN_TEMPLATE.toString());
+        markdownTemplatePage.setContent("Read the doc");
+        markdownTemplatePage.setVisibility(Visibility.PUBLIC);
+        PageEntity asciidocPage = new PageEntity();
+        asciidocPage.setName("My asciidoc");
+        asciidocPage.setOrder(1);
+        asciidocPage.setType(PageType.ASCIIDOC.toString());
+        asciidocPage.setContent("Read the asciidoc");
+        asciidocPage.setVisibility(Visibility.PUBLIC);
+        when(pageService.search(any(), eq(true)))
+            .thenReturn(
+                Arrays.asList(folder, markdownPage, swaggerPage, asideFolder, linkPage, translationPage, markdownTemplatePage, asciidocPage)
+            );
 
         RoleEntity poRole = new RoleEntity();
         poRole.setName("PRIMARY_OWNER");

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_15.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_15.json
@@ -9,16 +9,37 @@
     "username" : "johndoe-sourceId",
     "role" : "PRIMARY_OWNER"
   } ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "plans" : [ {
     "id" : "plan-id",
     "description" : "free plan",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_20.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_20.json
@@ -9,16 +9,37 @@
     "username":"johndoe-sourceId",
     "role" : "PRIMARY_OWNER"
   } ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "plans" : [ {
     "id" : "plan-id",
     "description" : "free plan",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_25.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-1_25.json
@@ -10,16 +10,37 @@
     "sourceId":"johndoe-sourceId",
     "role" : "PRIMARY_OWNER"
   } ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "plans" : [ {
     "id" : "plan-id",
     "description" : "free plan",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_0.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_0.json
@@ -21,15 +21,34 @@
       ]
     }
   ],
-  "pages": [
+  "pages" : [
     {
-      "name": "My Title",
-      "type": "MARKDOWN",
-      "content": "Read the doc",
-      "order": 1,
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
       "visibility": "PUBLIC",
-      "published": false,
-      "homepage": false,
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
       "excludedAccessControls": false
     },
     {
@@ -38,6 +57,26 @@
       "order": 1,
       "visibility": "PUBLIC",
       "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
       "homepage": false,
       "excludedAccessControls": false
     }

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_7.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport-3_7.json
@@ -1,6 +1,6 @@
 {
-  "description": "Gravitee.io 2.0.0",
-  "gravitee": "2.0.0",
+  "description": "Gravitee.io",
+  "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
   "primaryOwner": {
@@ -79,6 +79,16 @@
       "published": false,
       "homepage": false,
       "excludedAccessControls": false
+    },
+    {
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
     }
   ],
   "plans": [
@@ -122,6 +132,7 @@
       "apiId": "id-api"
     }
   ],
+  "id": "id-api",
   "path_mappings": [],
   "proxy": {
     "virtual_hosts": [
@@ -134,8 +145,8 @@
     "logging": {
       "mode": "CLIENT_PROXY",
       "condition": "condition",
-      "content":"NONE",
-      "scope":"NONE"
+      "content": "NONE",
+      "scope": "NONE"
     },
     "groups": [
       {

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExport.json
@@ -21,15 +21,34 @@
       ]
     }
   ],
-  "pages": [
+  "pages" : [
     {
-      "name": "My Title",
-      "type": "MARKDOWN",
-      "content": "Read the doc",
-      "order": 1,
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
       "visibility": "PUBLIC",
-      "published": false,
-      "homepage": false,
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
       "excludedAccessControls": false
     },
     {
@@ -38,6 +57,46 @@
       "order": 1,
       "visibility": "PUBLIC",
       "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My asciidoc",
+      "type": "ASCIIDOC",
+      "content" : "Read the asciidoc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
       "homepage": false,
       "excludedAccessControls": false
     }

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportMultipleEndpointGroups-1_15.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportMultipleEndpointGroups-1_15.json
@@ -9,16 +9,37 @@
     "username" : "johndoe-sourceId",
     "role" : "PRIMARY_OWNER"
   } ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "plans" : [ {
     "id" : "plan-id",
     "description" : "free plan",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithouGroup.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithouGroup.json
@@ -13,15 +13,35 @@
       "role": "PRIMARY_OWNER"
     }
   ],
-  "pages": [
+  "pages" : [
     {
-      "name": "My Title",
-      "type": "MARKDOWN",
-      "content": "Read the doc",
-      "order": 1,
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
       "visibility": "PUBLIC",
-      "published": false,
-      "homepage": false
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
     },
     {
       "name": "Aside",
@@ -29,6 +49,46 @@
       "order": 1,
       "visibility": "PUBLIC",
       "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My asciidoc",
+      "type": "ASCIIDOC",
+      "content" : "Read the asciidoc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
       "homepage": false,
       "excludedAccessControls": false
     }

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_15.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_15.json
@@ -5,16 +5,37 @@
   "properties" : [ ],
   "flow_mode": "DEFAULT",
   "groups" : [ "My Group" ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "plans" : [ {
     "id" : "plan-id",
     "description" : "free plan",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_20.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_20.json
@@ -6,16 +6,37 @@
   "flow_mode": "DEFAULT",
   "path_mappings":[],
   "groups" : [ "My Group" ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "plans" : [ {
     "id" : "plan-id",
     "description" : "free plan",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_25.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-1_25.json
@@ -6,16 +6,37 @@
   "flow_mode": "DEFAULT",
   "path_mappings":[],
   "groups" : [ "My Group" ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "plans" : [ {
     "id" : "plan-id",
     "description" : "free plan",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_0.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_0.json
@@ -12,11 +12,49 @@
   "groups": [
     "My Group"
   ],
-  "pages": [
+  "pages" : [
     {
-      "name": "My Title",
-      "type": "MARKDOWN",
-      "content": "Read the doc",
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "Aside",
+      "type": "SYSTEM_FOLDER",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
       "order": 1,
       "visibility": "PUBLIC",
       "published": false,
@@ -24,11 +62,12 @@
       "excludedAccessControls": false
     },
     {
-      "name": "Aside",
-      "type": "SYSTEM_FOLDER",
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
       "order": 1,
-      "published": true,
       "visibility": "PUBLIC",
+      "published": false,
       "homepage": false,
       "excludedAccessControls": false
     }

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_7.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers-3_7.json
@@ -1,6 +1,6 @@
 {
-  "description": "Gravitee.io 2.0.0",
-  "gravitee": "2.0.0",
+  "description": "Gravitee.io",
+  "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
   "primaryOwner": {
@@ -11,15 +11,6 @@
   "flow_mode": "DEFAULT",
   "groups": [
     "My Group"
-  ],
-  "members": [
-    {
-      "source": "johndoe-source",
-      "sourceId": "johndoe-sourceId",
-      "roles": [
-        "API_PRIMARY_OWNER"
-      ]
-    }
   ],
   "pages" : [
     {
@@ -79,6 +70,16 @@
       "published": false,
       "homepage": false,
       "excludedAccessControls": false
+    },
+    {
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
     }
   ],
   "plans": [
@@ -122,6 +123,7 @@
       "apiId": "id-api"
     }
   ],
+  "id": "id-api",
   "path_mappings": [],
   "proxy": {
     "virtual_hosts": [

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMembers.json
@@ -12,23 +12,82 @@
   "groups": [
     "My Group"
   ],
-  "pages": [
+  "pages" : [
     {
-      "name": "My Title",
-      "type": "MARKDOWN",
-      "content": "Read the doc",
-      "order": 1,
-      "published": false,
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
       "visibility": "PUBLIC",
-      "homepage": false,
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
       "excludedAccessControls": false
     },
     {
       "name": "Aside",
       "type": "SYSTEM_FOLDER",
       "order": 1,
-      "published": true,
       "visibility": "PUBLIC",
+      "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My asciidoc",
+      "type": "ASCIIDOC",
+      "content" : "Read the asciidoc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
       "homepage": false,
       "excludedAccessControls": false
     }

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_15.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_15.json
@@ -9,16 +9,37 @@
     "username" : "johndoe-sourceId",
     "role" : "PRIMARY_OWNER"
   } ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "plans" : [ {
     "id" : "plan-id",
     "description" : "free plan",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_20.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_20.json
@@ -9,16 +9,37 @@
     "username":"johndoe-sourceId",
     "role" : "PRIMARY_OWNER"
   } ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "plans" : [ {
     "id" : "plan-id",
     "description" : "free plan",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_25.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-1_25.json
@@ -10,16 +10,37 @@
     "sourceId":"johndoe-sourceId",
     "role" : "PRIMARY_OWNER"
   } ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "plans" : [ {
     "id" : "plan-id",
     "description" : "free plan",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_0.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_0.json
@@ -21,11 +21,49 @@
       ]
     }
   ],
-  "pages": [
+  "pages" : [
     {
-      "name": "My Title",
-      "type": "MARKDOWN",
-      "content": "Read the doc",
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "Aside",
+      "type": "SYSTEM_FOLDER",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
       "order": 1,
       "visibility": "PUBLIC",
       "published": false,
@@ -33,11 +71,12 @@
       "excludedAccessControls": false
     },
     {
-      "name": "Aside",
-      "type": "SYSTEM_FOLDER",
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
       "order": 1,
-      "published": true,
       "visibility": "PUBLIC",
+      "published": false,
       "homepage": false,
       "excludedAccessControls": false
     }

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_7.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata-3_7.json
@@ -1,6 +1,6 @@
 {
-  "description": "Gravitee.io 2.0.0",
-  "gravitee": "2.0.0",
+  "description": "Gravitee.io",
+  "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
   "primaryOwner": {
@@ -79,6 +79,16 @@
       "published": false,
       "homepage": false,
       "excludedAccessControls": false
+    },
+    {
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
     }
   ],
   "plans": [
@@ -112,16 +122,7 @@
       "comment_required": false
     }
   ],
-  "metadata": [
-    {
-      "key": "metadata-key",
-      "name": "metadata-name",
-      "format": "STRING",
-      "value": "metadata-value",
-      "defaultValue": "metadata-default-value",
-      "apiId": "id-api"
-    }
-  ],
+  "id": "id-api",
   "path_mappings": [],
   "proxy": {
     "virtual_hosts": [

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutMetadata.json
@@ -21,11 +21,49 @@
       ]
     }
   ],
-  "pages": [
+  "pages" : [
     {
-      "name": "My Title",
-      "type": "MARKDOWN",
-      "content": "Read the doc",
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "Aside",
+      "type": "SYSTEM_FOLDER",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
       "order": 1,
       "visibility": "PUBLIC",
       "published": false,
@@ -33,11 +71,32 @@
       "excludedAccessControls": false
     },
     {
-      "name": "Aside",
-      "type": "SYSTEM_FOLDER",
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
       "order": 1,
-      "published": true,
       "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My asciidoc",
+      "type": "ASCIIDOC",
+      "content" : "Read the asciidoc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
       "homepage": false,
       "excludedAccessControls": false
     }

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-3_7.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPages-3_7.json
@@ -1,6 +1,6 @@
 {
-  "description": "Gravitee.io 2.0.0",
-  "gravitee": "2.0.0",
+  "description": "Gravitee.io",
+  "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
   "primaryOwner": {
@@ -19,66 +19,6 @@
       "roles": [
         "API_PRIMARY_OWNER"
       ]
-    }
-  ],
-  "pages" : [
-    {
-      "name" : "My Folder",
-      "type" : "FOLDER",
-      "order" : 1,
-      "visibility": "PUBLIC",
-      "published" : false,
-      "homepage" : false,
-      "excludedAccessControls": false
-    },
-    {
-      "name" : "My Title",
-      "type" : "MARKDOWN",
-      "content" : "Read the doc",
-      "order" : 1,
-      "visibility": "PUBLIC",
-      "published" : false,
-      "homepage" : false,
-      "excludedAccessControls": false
-    },
-    {
-      "name" : "My Swagger",
-      "type" : "SWAGGER",
-      "content" : "Read the doc",
-      "order" : 1,
-      "visibility": "PUBLIC",
-      "published" : false,
-      "homepage" : false,
-      "excludedAccessControls": false
-    },
-    {
-      "name": "Aside",
-      "type": "SYSTEM_FOLDER",
-      "order": 1,
-      "visibility": "PUBLIC",
-      "published": true,
-      "homepage": false,
-      "excludedAccessControls": false
-    },
-    {
-      "name": "My Link",
-      "type": "LINK",
-      "content" : "Read the doc",
-      "order": 1,
-      "visibility": "PUBLIC",
-      "published": false,
-      "homepage": false,
-      "excludedAccessControls": false
-    },
-    {
-      "name": "My Translation",
-      "type": "TRANSLATION",
-      "content" : "Lire la documentation",
-      "order": 1,
-      "visibility": "PUBLIC",
-      "published": false,
-      "homepage": false,
-      "excludedAccessControls": false
     }
   ],
   "plans": [
@@ -122,6 +62,7 @@
       "apiId": "id-api"
     }
   ],
+  "id": "id-api",
   "path_mappings": [],
   "proxy": {
     "virtual_hosts": [

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-1_15.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-1_15.json
@@ -9,16 +9,37 @@
     "username" : "johndoe-sourceId",
     "role" : "PRIMARY_OWNER"
   } ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "metadata":[
     {
       "key":"metadata-key",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-1_20.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-1_20.json
@@ -10,16 +10,37 @@
     "username":"johndoe-sourceId",
     "role" : "PRIMARY_OWNER"
   } ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "metadata":[
     {
       "key":"metadata-key",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-1_25.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-1_25.json
@@ -11,16 +11,37 @@
     "sourceId":"johndoe-sourceId",
     "role" : "PRIMARY_OWNER"
   } ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "metadata":[
     {
       "key":"metadata-key",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-3_0.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-3_0.json
@@ -21,11 +21,49 @@
       ]
     }
   ],
-  "pages": [
+  "pages" : [
     {
-      "name": "My Title",
-      "type": "MARKDOWN",
-      "content": "Read the doc",
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "Aside",
+      "type": "SYSTEM_FOLDER",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
       "order": 1,
       "visibility": "PUBLIC",
       "published": false,
@@ -33,11 +71,12 @@
       "excludedAccessControls": false
     },
     {
-      "name": "Aside",
-      "type": "SYSTEM_FOLDER",
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
       "order": 1,
-      "published": true,
       "visibility": "PUBLIC",
+      "published": false,
       "homepage": false,
       "excludedAccessControls": false
     }

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-3_7.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans-3_7.json
@@ -1,14 +1,14 @@
 {
-  "description": "Gravitee.io 2.0.0",
-  "gravitee": "2.0.0",
+  "description": "Gravitee.io",
+  "gravitee": "1.0.0",
   "resources": [],
-  "properties": [],
+  "properties" : [ ],
+  "flow_mode": "DEFAULT",
   "primaryOwner": {
     "id": "johndoe",
     "displayName": "johndoe-sourceId",
     "type": "USER"
   },
-  "flow_mode": "DEFAULT",
   "groups": [
     "My Group"
   ],
@@ -79,37 +79,16 @@
       "published": false,
       "homepage": false,
       "excludedAccessControls": false
-    }
-  ],
-  "plans": [
+    },
     {
-      "id": "plan-id",
-      "description": "free plan",
-      "validation": "AUTO",
-      "security": "API_KEY",
-      "type": "API",
-      "status": "PUBLISHED",
-      "api": "id-api",
-      "order": 0,
-      "paths": {
-        "/": [
-          {
-            "methods": [
-              "GET"
-            ],
-            "rate-limit": {
-              "rate": {
-                "limit": 1,
-                "periodTime": 1,
-                "periodTimeUnit": "SECONDS"
-              }
-            },
-            "enabled": true
-          }
-        ]
-      },
-      "flows": [],
-      "comment_required": false
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
     }
   ],
   "metadata": [
@@ -122,6 +101,7 @@
       "apiId": "id-api"
     }
   ],
+  "id": "id-api",
   "path_mappings": [],
   "proxy": {
     "virtual_hosts": [

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-convertAsJsonForExportWithoutPlans.json
@@ -21,15 +21,34 @@
       ]
     }
   ],
-  "pages": [
+  "pages" : [
     {
-      "name": "My Title",
-      "type": "MARKDOWN",
-      "content": "Read the doc",
-      "order": 1,
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
       "visibility": "PUBLIC",
-      "published": false,
-      "homepage": false,
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
       "excludedAccessControls": false
     },
     {
@@ -38,6 +57,46 @@
       "order": 1,
       "visibility": "PUBLIC",
       "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My asciidoc",
+      "type": "ASCIIDOC",
+      "content" : "Read the asciidoc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
       "homepage": false,
       "excludedAccessControls": false
     }

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_15.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_15.json
@@ -9,16 +9,37 @@
     "username" : "johndoe-sourceId",
     "role" : "PRIMARY_OWNER"
   } ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "plans" : [ {
     "id" : "plan-id",
     "description" : "free plan",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_20.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_20.json
@@ -9,16 +9,37 @@
     "username":"johndoe-sourceId",
     "role" : "PRIMARY_OWNER"
   } ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "plans" : [ {
     "id" : "plan-id",
     "description" : "free plan",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_25.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-1_25.json
@@ -10,16 +10,37 @@
     "sourceId":"johndoe-sourceId",
     "role" : "PRIMARY_OWNER"
   } ],
-  "pages" : [ {
-    "name" : "My Title",
-    "type" : "MARKDOWN",
-    "content" : "Read the doc",
-    "order" : 1,
-    "visibility": "PUBLIC",
-    "published" : false,
-    "homepage" : false,
-    "excludedAccessControls": false
-  } ],
+  "pages" : [
+    {
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    }
+  ],
   "plans" : [ {
     "id" : "plan-id",
     "description" : "free plan",

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_0.json
@@ -21,15 +21,34 @@
       ]
     }
   ],
-  "pages": [
+  "pages" : [
     {
-      "name": "My Title",
-      "type": "MARKDOWN",
-      "content": "Read the doc",
-      "order": 1,
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
       "visibility": "PUBLIC",
-      "published": false,
-      "homepage": false,
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
       "excludedAccessControls": false
     },
     {
@@ -38,6 +57,26 @@
       "order": 1,
       "visibility": "PUBLIC",
       "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
       "homepage": false,
       "excludedAccessControls": false
     }

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_7.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport-3_7.json
@@ -1,6 +1,6 @@
 {
-  "description": "Gravitee.io 2.0.0",
-  "gravitee": "2.0.0",
+  "description": "Gravitee.io",
+  "gravitee": "1.0.0",
   "resources": [],
   "properties": [],
   "primaryOwner": {
@@ -79,6 +79,16 @@
       "published": false,
       "homepage": false,
       "excludedAccessControls": false
+    },
+    {
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
     }
   ],
   "plans": [
@@ -122,6 +132,7 @@
       "apiId": "id-api"
     }
   ],
+  "id": "id-api",
   "path_mappings": [],
   "proxy": {
     "virtual_hosts": [
@@ -156,6 +167,25 @@
               "maxConcurrentConnections": 100,
               "useCompression": true,
               "followRedirects": false
+            }
+          },
+          {
+            "name": "EndPoint GRPC",
+            "target": "grpc://localhost:8888",
+            "weight": 1,
+            "backup": false,
+            "type": "GRPC",
+            "http": {
+              "connectTimeout": 5000,
+              "idleTimeout": 60000,
+              "keepAlive": true,
+              "readTimeout": 10000,
+              "pipelining": false,
+              "maxConcurrentConnections": 100,
+              "useCompression": true,
+              "followRedirects": false,
+              "version": "HTTP_2",
+              "clearTextUpgrade": true
             }
           }
         ],

--- a/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport.json
+++ b/gravitee-rest-api-service/src/test/resources/io/gravitee/rest/api/management/service/export-gRPC-convertAsJsonForExport.json
@@ -21,11 +21,49 @@
       ]
     }
   ],
-  "pages": [
+  "pages" : [
     {
-      "name": "My Title",
-      "type": "MARKDOWN",
-      "content": "Read the doc",
+      "name" : "My Folder",
+      "type" : "FOLDER",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Title",
+      "type" : "MARKDOWN",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name" : "My Swagger",
+      "type" : "SWAGGER",
+      "content" : "Read the doc",
+      "order" : 1,
+      "visibility": "PUBLIC",
+      "published" : false,
+      "homepage" : false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "Aside",
+      "type": "SYSTEM_FOLDER",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": true,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Link",
+      "type": "LINK",
+      "content" : "Read the doc",
       "order": 1,
       "visibility": "PUBLIC",
       "published": false,
@@ -33,11 +71,32 @@
       "excludedAccessControls": false
     },
     {
-      "name": "Aside",
-      "type": "SYSTEM_FOLDER",
+      "name": "My Translation",
+      "type": "TRANSLATION",
+      "content" : "Lire la documentation",
       "order": 1,
-      "published": true,
       "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My Template",
+      "type": "MARKDOWN_TEMPLATE",
+      "content" : "Read the doc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
+      "homepage": false,
+      "excludedAccessControls": false
+    },
+    {
+      "name": "My asciidoc",
+      "type": "ASCIIDOC",
+      "content" : "Read the asciidoc",
+      "order": 1,
+      "visibility": "PUBLIC",
+      "published": false,
       "homepage": false,
       "excludedAccessControls": false
     }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/4717

**Description**

* add new page type for AsciiDoc
* modify import/export of API to filter page type regarding the target version
