### PR TITLE
fix: replace string generator for unit test

### DIFF
--- a/gravitee-rest-api-service/pom.xml
+++ b/gravitee-rest-api-service/pom.xml
@@ -257,6 +257,11 @@
             <groupId>io.gravitee.node</groupId>
             <artifactId>gravitee-node-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 	<build>

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtilsTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/sanitizer/UrlSanitizerUtilsTest.java
@@ -21,6 +21,7 @@ import io.gravitee.rest.api.service.exceptions.InvalidDataException;
 import io.gravitee.rest.api.service.exceptions.UrlForbiddenException;
 import java.util.Collections;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.text.RandomStringGenerator;
 import org.junit.Test;
 
 /**
@@ -51,7 +52,8 @@ public class UrlSanitizerUtilsTest {
 
     @Test(expected = InvalidDataException.class)
     public void checkAllowed_invalidUrl() {
-        UrlSanitizerUtils.checkAllowed("https://invalid-url.not-exist" + RandomStringUtils.random(5), Collections.emptyList(), false);
+        RandomStringGenerator generator = new RandomStringGenerator.Builder().withinRange('a', 'z').build();
+        UrlSanitizerUtils.checkAllowed("https://invalid-url.not-exist" + generator.generate(5), Collections.emptyList(), false);
     }
 
     @Test(expected = UrlForbiddenException.class)

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <lucene.version>7.5.0</lucene.version>
         <powermock.version>2.0.0</powermock.version>
         <commons-lang3.version>3.9</commons-lang3.version>
+        <commons-text.version>1.9</commons-text.version>
         <swagger.version>1.6.2</swagger.version>
         <nimbus-jose-jwt.version>8.15</nimbus-jose-jwt.version>
         <flexmark.version>0.61.16</flexmark.version>
@@ -308,6 +309,11 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>${commons-lang3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>${commons-text.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5822

**Description**

Sometimes `RandomStringUtils` generate characters that make the URL invalid. This implies that sometimes, the `checkAllowed_invalidUrl` method fails with an UrlForbiddenException instead of InvalidDataException.

This commit replaces `RandomStringUtils` with `RandomStringGenerator` that allows to generate safe characters.

