### PR TITLE
chore: use new APIM monorepo as dependency - 3.8.x

### DIFF
--- a/gravitee-rest-api-repository/pom.xml
+++ b/gravitee-rest-api-repository/pom.xml
@@ -33,8 +33,8 @@
 	<dependencies>
 		<!-- Gravitee.io dependencies -->
 		<dependency>
-			<groupId>io.gravitee.repository</groupId>
-			<artifactId>gravitee-repository</artifactId>
+			<groupId>io.gravitee.apim.repository</groupId>
+			<artifactId>gravitee-apim-repository-api</artifactId>
 		</dependency>
 
 		<dependency>

--- a/gravitee-rest-api-service/pom.xml
+++ b/gravitee-rest-api-service/pom.xml
@@ -86,8 +86,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>io.gravitee.repository</groupId>
-			<artifactId>gravitee-repository</artifactId>
+			<groupId>io.gravitee.apim.repository</groupId>
+			<artifactId>gravitee-apim-repository-api</artifactId>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
         <gravitee-common.version>1.20.1</gravitee-common.version>
         <gravitee-definition.version>1.27.1</gravitee-definition.version>
         <gravitee-plugin.version>1.16.0</gravitee-plugin.version>
-        <gravitee-repository.version>3.8.3</gravitee-repository.version>
         <gravitee-gateway-api.version>1.20.1</gravitee-gateway-api.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-expression-language.version>1.5.0</gravitee-expression-language.version>
@@ -110,9 +109,9 @@
                 <version>${gravitee-node.version}</version>
             </dependency>
             <dependency>
-                <groupId>io.gravitee.repository</groupId>
-                <artifactId>gravitee-repository</artifactId>
-                <version>${gravitee-repository.version}</version>
+                <groupId>io.gravitee.apim.repository</groupId>
+                <artifactId>gravitee-apim-repository-api</artifactId>
+                <version>${project.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.gravitee.common</groupId>


### PR DESCRIPTION
**Description**

Use the new APIM mono-repository [gravitee-api-management](https://github.com/gravitee-io/gravitee-api-management) to replace `gravitee-repository`


