### PR TITLE
chore: update gravitee-api-management dependency - 3.9.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <gravitee-alert-api.version>1.7.1</gravitee-alert-api.version>
         <gravitee-policy-api.version>1.11.0</gravitee-policy-api.version>
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
+        <gravitee-api-management.version>3.9.3-SNAPSHOT</gravitee-api-management.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-resource-cache-provider-api.version>1.0.0</gravitee-resource-cache-provider-api.version>
         <gravitee-cockpit-api.version>1.5.0</gravitee-cockpit-api.version>
@@ -111,7 +112,7 @@
             <dependency>
                 <groupId>io.gravitee.apim.repository</groupId>
                 <artifactId>gravitee-apim-repository-api</artifactId>
-                <version>${project.version}</version>
+                <version>${gravitee-api-management.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.gravitee.common</groupId>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5821

**Description**

use a specific version for the dependency instead of `project.version`
