### PR TITLE
Manage in progress promotion

### DIFF
--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/promotion/PromotionQuery.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/promotion/PromotionQuery.java
@@ -24,7 +24,7 @@ import java.util.List;
 public class PromotionQuery {
 
     private List<String> targetEnvCockpitIds;
-    private PromotionEntityStatus status;
+    private List<PromotionEntityStatus> statuses;
     private Boolean targetApiExists;
     private String apiId;
 
@@ -36,12 +36,12 @@ public class PromotionQuery {
         this.targetEnvCockpitIds = targetEnvCockpitIds;
     }
 
-    public PromotionEntityStatus getStatus() {
-        return status;
+    public List<PromotionEntityStatus> getStatuses() {
+        return statuses;
     }
 
-    public void setStatus(PromotionEntityStatus status) {
-        this.status = status;
+    public void setStatuses(List<PromotionEntityStatus> statuses) {
+        this.statuses = statuses;
     }
 
     public void setTargetApiExists(Boolean targetApiExists) {

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/PromotionAlreadyInProgressException.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/exceptions/PromotionAlreadyInProgressException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.service.exceptions;
+
+import static java.util.Collections.singletonMap;
+
+import java.util.Map;
+
+public class PromotionAlreadyInProgressException extends AbstractNotFoundException {
+
+    private final String otherPromotionId;
+
+    public PromotionAlreadyInProgressException(String otherPromotionId) {
+        this.otherPromotionId = otherPromotionId;
+    }
+
+    @Override
+    public String getMessage() {
+        return "Another promotion for the same API and environment is already in progress: Promotion [" + otherPromotionId + "].";
+    }
+
+    @Override
+    public String getTechnicalCode() {
+        return "promotion.alreadyInProgress";
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return singletonMap("promotion", otherPromotionId);
+    }
+}

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
@@ -29,7 +29,6 @@ import io.gravitee.repository.management.api.search.Order;
 import io.gravitee.repository.management.api.search.PromotionCriteria;
 import io.gravitee.repository.management.api.search.builder.PageableBuilder;
 import io.gravitee.repository.management.api.search.builder.SortableBuilder;
-import io.gravitee.repository.management.model.Audit;
 import io.gravitee.repository.management.model.Promotion;
 import io.gravitee.repository.management.model.PromotionAuthor;
 import io.gravitee.repository.management.model.PromotionStatus;
@@ -58,7 +57,7 @@ import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.AbstractService;
 import io.gravitee.rest.api.service.jackson.ser.api.ApiSerializer;
 import io.gravitee.rest.api.service.promotion.PromotionService;
-import java.util.*;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
@@ -240,7 +239,7 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
             existing.setStatus(accepted ? PromotionStatus.ACCEPTED : PromotionStatus.REJECTED);
 
             final PromotionQuery promotionQuery = new PromotionQuery();
-            promotionQuery.setStatus(PromotionEntityStatus.ACCEPTED);
+            promotionQuery.setStatuses(Collections.singletonList(PromotionEntityStatus.ACCEPTED));
             promotionQuery.setTargetEnvCockpitIds(singletonList(existing.getTargetEnvCockpitId()));
             promotionQuery.setTargetApiExists(true);
             promotionQuery.setApiId(existing.getApiId());
@@ -384,8 +383,8 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
         if (!CollectionUtils.isEmpty(query.getTargetEnvCockpitIds())) {
             builder.targetEnvCockpitIds(query.getTargetEnvCockpitIds().toArray(new String[0]));
         }
-        if (query.getStatus() != null) {
-            builder.status(convert(query.getStatus()));
+        if (query.getStatuses() != null) {
+            builder.statuses(query.getStatuses().stream().map(this::convert).collect(Collectors.toList()));
         }
 
         if (query.getTargetApiExists() != null) {

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionTasksServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionTasksServiceImpl.java
@@ -19,7 +19,6 @@ import static io.gravitee.rest.api.model.permissions.RolePermission.ENVIRONMENT_
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -87,13 +86,13 @@ public class PromotionTasksServiceImpl extends AbstractService implements Promot
         List<String> envCockpitIds = environments.stream().map(EnvironmentEntity::getCockpitId).filter(Objects::nonNull).collect(toList());
 
         final PromotionQuery promotionQuery = new PromotionQuery();
-        promotionQuery.setStatus(PromotionEntityStatus.TO_BE_VALIDATED);
+        promotionQuery.setStatuses(Collections.singletonList(PromotionEntityStatus.TO_BE_VALIDATED));
         promotionQuery.setTargetEnvCockpitIds(envCockpitIds);
 
         final Page<PromotionEntity> promotionsPage = promotionService.search(promotionQuery, new SortableImpl("created_at", false), null);
 
         final PromotionQuery previousPromotionsQuery = new PromotionQuery();
-        previousPromotionsQuery.setStatus(PromotionEntityStatus.ACCEPTED);
+        previousPromotionsQuery.setStatuses(Collections.singletonList(PromotionEntityStatus.ACCEPTED));
         previousPromotionsQuery.setTargetEnvCockpitIds(envCockpitIds);
         previousPromotionsQuery.setTargetApiExists(true);
 

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionTasksServiceImplTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/impl/promotion/PromotionTasksServiceImplTest.java
@@ -17,7 +17,6 @@ package io.gravitee.rest.api.service.impl.promotion;
 
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.CREATE;
 import static io.gravitee.rest.api.model.permissions.RolePermissionAction.UPDATE;
-import static io.gravitee.rest.api.model.promotion.PromotionEntityStatus.TO_BE_VALIDATED;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -102,7 +101,7 @@ public class PromotionTasksServiceImplTest {
         PromotionEntity aPromotionEntity = getAPromotionEntity();
         when(
             promotionService.search(
-                argThat(query -> query != null && query.getStatus() == PromotionEntityStatus.TO_BE_VALIDATED),
+                argThat(query -> query != null && query.getStatuses().get(0) == PromotionEntityStatus.TO_BE_VALIDATED),
                 any(),
                 any()
             )
@@ -112,7 +111,13 @@ public class PromotionTasksServiceImplTest {
 
         PromotionEntity previousPromotionEntity = getAPromotionEntity();
         previousPromotionEntity.setTargetApiId("api#target");
-        when(promotionService.search(argThat(query -> query != null && query.getStatus() == PromotionEntityStatus.ACCEPTED), any(), any()))
+        when(
+            promotionService.search(
+                argThat(query -> query != null && query.getStatuses().get(0) == PromotionEntityStatus.ACCEPTED),
+                any(),
+                any()
+            )
+        )
             .thenReturn(new Page<>(singletonList(previousPromotionEntity), 0, 0, 0));
         when(permissionService.hasPermission(RolePermission.ENVIRONMENT_API, "env#1", CREATE, UPDATE)).thenReturn(true);
         when(objectMapper.readValue(aPromotionEntity.getApiDefinition(), ApiEntity.class)).thenReturn(getAnApiEntity());
@@ -138,7 +143,7 @@ public class PromotionTasksServiceImplTest {
         PromotionEntity aPromotionEntity = getAPromotionEntity();
         when(
             promotionService.search(
-                argThat(query -> query != null && query.getStatus() == PromotionEntityStatus.TO_BE_VALIDATED),
+                argThat(query -> query != null && query.getStatuses().get(0) == PromotionEntityStatus.TO_BE_VALIDATED),
                 any(),
                 any()
             )
@@ -146,7 +151,13 @@ public class PromotionTasksServiceImplTest {
             .thenReturn(new Page<>(singletonList(aPromotionEntity), 0, 0, 0));
         when(environmentService.findByOrganization(any())).thenReturn(singletonList(getAnEnvironmentEntity()));
 
-        when(promotionService.search(argThat(query -> query != null && query.getStatus() == PromotionEntityStatus.ACCEPTED), any(), any()))
+        when(
+            promotionService.search(
+                argThat(query -> query != null && query.getStatuses().get(0) == PromotionEntityStatus.ACCEPTED),
+                any(),
+                any()
+            )
+        )
             .thenReturn(new Page<>(emptyList(), 0, 0, 0));
         when(permissionService.hasPermission(RolePermission.ENVIRONMENT_API, "env#1", CREATE, UPDATE)).thenReturn(true);
         when(objectMapper.readValue(aPromotionEntity.getApiDefinition(), ApiEntity.class)).thenReturn(getAnApiEntity());
@@ -170,7 +181,7 @@ public class PromotionTasksServiceImplTest {
         PromotionEntity aPromotionEntity = getAPromotionEntity();
         when(
             promotionService.search(
-                argThat(query -> query != null && query.getStatus() == PromotionEntityStatus.TO_BE_VALIDATED),
+                argThat(query -> query != null && query.getStatuses().get(0) == PromotionEntityStatus.TO_BE_VALIDATED),
                 any(),
                 any()
             )
@@ -180,7 +191,13 @@ public class PromotionTasksServiceImplTest {
 
         PromotionEntity previousPromotionEntity = getAPromotionEntity();
         previousPromotionEntity.setTargetApiId("api#target");
-        when(promotionService.search(argThat(query -> query != null && query.getStatus() == PromotionEntityStatus.ACCEPTED), any(), any()))
+        when(
+            promotionService.search(
+                argThat(query -> query != null && query.getStatuses().get(0) == PromotionEntityStatus.ACCEPTED),
+                any(),
+                any()
+            )
+        )
             .thenReturn(new Page<>(singletonList(previousPromotionEntity), 0, 0, 0));
         when(permissionService.hasPermission(RolePermission.ENVIRONMENT_API, "env#1", CREATE, UPDATE)).thenReturn(true);
         when(objectMapper.readValue(aPromotionEntity.getApiDefinition(), ApiEntity.class)).thenReturn(getAnApiEntity());


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5746

**Description**

 - Handle multiple statuses in PromotionQuery
 - Add endpoint to search API promotions
 - Prevent users from being able to select an env already targeted by a CREATED or TO_BE_VALIDATED promotion