### PR TITLE
Add scopes in all BridgeCommand's targets

### DIFF
--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/bridge/BridgeCommandFactory.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/cockpit/command/bridge/BridgeCommandFactory.java
@@ -22,6 +22,7 @@ import io.gravitee.rest.api.service.InstallationService;
 import io.gravitee.rest.api.service.cockpit.command.bridge.operation.BridgeOperation;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.Collections;
+import java.util.List;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -56,6 +57,7 @@ public class BridgeCommandFactory {
         createPromoteApiCommand.setPayload(payload);
 
         BridgeTarget target = new BridgeTarget();
+        target.setScopes(Collections.singletonList(BRIDGE_SCOPE_APIM));
         target.setEnvironmentId(targetEnvironmentId);
         createPromoteApiCommand.setTarget(target);
 
@@ -71,6 +73,7 @@ public class BridgeCommandFactory {
         processPromotionCommand.setPayload(payload);
 
         BridgeTarget target = new BridgeTarget();
+        target.setScopes(Collections.singletonList(BRIDGE_SCOPE_APIM));
         target.setEnvironmentId(sourceEnvCockpitId);
         processPromotionCommand.setTarget(target);
 


### PR DESCRIPTION
**Issue**

NA

**Description**

An environment can be linked to both an APIM and AM installation on Cockpit.
So to be able to send a command to the correct app cockpit need to know if it's targeting APIM or AM.
To avoid any issue we need to set a target scope for all BridgeCommand.

