### PR TITLE
fix(management): fix HttpClientServiceImpl after update to vertx 4

### DIFF
--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/HttpClientServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/HttpClientServiceImpl.java
@@ -134,17 +134,21 @@ public class HttpClientServiceImpl extends AbstractService implements HttpClient
             .setMethod(io.vertx.core.http.HttpMethod.valueOf(method.name()))
             .setHost(requestUri.getHost())
             .setPort(port)
-            .setURI(requestUri.toString())
+            .setURI(requestUri.getPath())
             .setTimeout(httpClientTimeout);
 
         //headers
-        options.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
-        options.putHeader(HttpHeaders.CONTENT_LENGTH, Integer.toString(body.getBytes().length));
-        headers.forEach(options::putHeader);
-        options.putHeader("X-Gravitee-Request-Id", RandomString.generate());
+        if (headers != null) {
+            headers.forEach(options::putHeader);
+        }
 
-        if (!options.getHeaders().contains(HttpHeaders.CONTENT_TYPE)) {
-            options.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        options.putHeader("X-Gravitee-Request-Id", RandomString.generate().trim());
+
+        if (body != null) {
+            if (!options.getHeaders().contains(HttpHeaders.CONTENT_TYPE)) {
+                options.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+            }
+            options.putHeader(HttpHeaders.CONTENT_LENGTH, Integer.toString(body.getBytes().length));
         }
 
         Future<HttpClientRequest> requestFuture = httpClient.request(options);
@@ -220,7 +224,11 @@ public class HttpClientServiceImpl extends AbstractService implements HttpClient
                                 }
                             );
 
-                        request.end(body);
+                        if (body != null) {
+                            request.end(body);
+                        } else {
+                            request.end();
+                        }
                     }
                 }
             );


### PR DESCRIPTION
Issue https://github.com/gravitee-io/issues/issues/5881

**Description**

Impossible to import API from URL due to bug on HttpServiceImpl after update to Vert.x 4

**What has been done**

- Use request's path in `requestOptions.setURI` (which is a relative URI)
- Handle null parameters for
  - headers
  - body


## How to test ?

Try to import an API by URL using https://api.gravitee.io/api-echo.json
