### PR TITLE
Extract calls to `GraviteeContext.getCurrentEnv/Org` from PageService methods

### DIFF
--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPagesResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiPagesResource.java
@@ -27,6 +27,7 @@ import io.gravitee.rest.api.model.permissions.RolePermissionAction;
 import io.gravitee.rest.api.service.AccessControlService;
 import io.gravitee.rest.api.service.ApiService;
 import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ForbiddenAccessException;
 import io.gravitee.rest.api.service.exceptions.PageMarkdownTemplateActionException;
 import io.gravitee.rest.api.service.exceptions.PageSystemFolderActionException;
@@ -96,7 +97,8 @@ public class ApiPagesResource extends AbstractResource {
             return pageService
                 .search(
                     new PageQuery.Builder().api(api).homepage(homepage).type(type).parent(parent).name(name).rootParent(rootParent).build(),
-                    translated ? acceptedLocale : null
+                    translated ? acceptedLocale : null,
+                    GraviteeContext.getCurrentEnvironment()
                 )
                 .stream()
                 .filter(page -> isDisplayable(apiEntity, page))
@@ -134,7 +136,7 @@ public class ApiPagesResource extends AbstractResource {
         int order = pageService.findMaxApiPageOrderByApi(api) + 1;
         newPageEntity.setOrder(order);
         newPageEntity.setLastContributor(getAuthenticatedUser());
-        PageEntity newPage = pageService.createPage(api, newPageEntity);
+        PageEntity newPage = pageService.createPage(api, newPageEntity, GraviteeContext.getCurrentEnvironment());
         if (newPage != null) {
             return Response.created(this.getLocationHeader(newPage.getId())).entity(newPage).build();
         }
@@ -158,7 +160,7 @@ public class ApiPagesResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.API_DOCUMENTATION, acls = RolePermissionAction.UPDATE) })
     public Response fetchAllApiPages() {
         String contributor = getAuthenticatedUser();
-        pageService.fetchAll(new PageQuery.Builder().api(api).build(), contributor);
+        pageService.fetchAll(new PageQuery.Builder().api(api).build(), contributor, GraviteeContext.getCurrentEnvironment());
         return Response.noContent().build();
     }
 
@@ -181,7 +183,7 @@ public class ApiPagesResource extends AbstractResource {
     @Permissions({ @Permission(value = RolePermission.API_DOCUMENTATION, acls = RolePermissionAction.CREATE) })
     public List<PageEntity> importApiPageFiles(@ApiParam(name = "page", required = true) @Valid @NotNull ImportPageEntity pageEntity) {
         pageEntity.setLastContributor(getAuthenticatedUser());
-        return pageService.importFiles(api, pageEntity);
+        return pageService.importFiles(api, pageEntity, GraviteeContext.getCurrentEnvironment());
     }
 
     @PUT
@@ -200,7 +202,7 @@ public class ApiPagesResource extends AbstractResource {
         @ApiParam(name = "page", required = true) @Valid @NotNull ImportPageEntity pageEntity
     ) {
         pageEntity.setLastContributor(getAuthenticatedUser());
-        return pageService.importFiles(api, pageEntity);
+        return pageService.importFiles(api, pageEntity, GraviteeContext.getCurrentEnvironment());
     }
 
     private boolean isDisplayable(ApiEntity api, PageEntity page) {

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApiResource.java
@@ -42,6 +42,7 @@ import io.gravitee.rest.api.model.promotion.PromotionEntity;
 import io.gravitee.rest.api.model.promotion.PromotionRequestEntity;
 import io.gravitee.rest.api.security.utils.ImageUtils;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import io.gravitee.rest.api.service.promotion.PromotionService;
 import io.swagger.annotations.*;
@@ -384,7 +385,12 @@ public class ApiResource extends AbstractResource {
     )
     @Permissions({ @Permission(value = RolePermission.API_DEFINITION, acls = RolePermissionAction.UPDATE) })
     public Response updateApiWithDefinition(@ApiParam(name = "definition", required = true) String apiDefinition) {
-        ApiEntity updatedApi = apiDuplicatorService.createWithImportedDefinition(apiDefinition, getAuthenticatedUser());
+        ApiEntity updatedApi = apiDuplicatorService.createWithImportedDefinition(
+            apiDefinition,
+            getAuthenticatedUser(),
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
         return Response
             .ok(updatedApi)
             .tag(Long.toString(updatedApi.getUpdatedAt().getTime()))
@@ -409,7 +415,13 @@ public class ApiResource extends AbstractResource {
     public Response updateWithDefinitionPUT(@ApiParam(name = "definition", required = true) String apiDefinition) {
         final ApiEntity apiEntity = (ApiEntity) getApi().getEntity();
 
-        ApiEntity updatedApi = apiDuplicatorService.updateWithImportedDefinition(apiEntity.getId(), apiDefinition, getAuthenticatedUser());
+        ApiEntity updatedApi = apiDuplicatorService.updateWithImportedDefinition(
+            apiEntity.getId(),
+            apiDefinition,
+            getAuthenticatedUser(),
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
         return Response
             .ok(updatedApi)
             .tag(Long.toString(updatedApi.getUpdatedAt().getTime()))
@@ -649,7 +661,16 @@ public class ApiResource extends AbstractResource {
     )
     public Response duplicateAPI(@ApiParam(name = "api", required = true) @Valid @NotNull final DuplicateApiEntity duplicateApiEntity) {
         final ApiEntity apiEntity = (ApiEntity) getApi().getEntity(); // call this method to check READ permission on source API.
-        return Response.ok(apiDuplicatorService.duplicate(apiEntity, duplicateApiEntity)).build();
+        return Response
+            .ok(
+                apiDuplicatorService.duplicate(
+                    apiEntity,
+                    duplicateApiEntity,
+                    GraviteeContext.getCurrentOrganization(),
+                    GraviteeContext.getCurrentEnvironment()
+                )
+            )
+            .build();
     }
 
     @POST

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/main/java/io/gravitee/rest/api/management/rest/resource/ApisResource.java
@@ -237,7 +237,12 @@ public class ApisResource extends AbstractResource {
         @ApiParam(name = "definition", required = true) @Valid @NotNull String apiDefinition,
         @QueryParam("definitionVersion") @DefaultValue("1.0.0") String definitionVersion
     ) {
-        ApiEntity imported = apiDuplicatorService.createWithImportedDefinition(apiDefinition, getAuthenticatedUser());
+        ApiEntity imported = apiDuplicatorService.createWithImportedDefinition(
+            apiDefinition,
+            getAuthenticatedUser(),
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
         if (
             DefinitionVersion.valueOfLabel(definitionVersion).equals(DefinitionVersion.V2) &&

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiPagesResourceAdminTest.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApiPagesResourceAdminTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.*;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -180,8 +181,8 @@ public class ApiPagesResourceAdminTest extends AbstractResourceTest {
 
         PageEntity returnedPage = new PageEntity();
         returnedPage.setId("my-beautiful-page");
-        doReturn(returnedPage).when(pageService).createPage(eq(API_NAME), any());
-        doReturn(0).when(pageService).findMaxPortalPageOrder();
+        doReturn(returnedPage).when(pageService).createPage(eq(API_NAME), any(), eq(GraviteeContext.getCurrentEnvironment()));
+        doReturn(0).when(pageService).findMaxPortalPageOrder(eq(GraviteeContext.getCurrentEnvironment()));
 
         final Response response = envTarget().request().post(Entity.json(newPageEntity));
 

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApisResourceTest.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/ApisResourceTest.java
@@ -24,6 +24,7 @@ import io.gravitee.definition.model.DefinitionVersion;
 import io.gravitee.rest.api.model.ImportSwaggerDescriptorEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.NewApiEntity;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -123,7 +124,14 @@ public class ApisResourceTest extends AbstractResourceTest {
         ApiEntity createdApi = new ApiEntity();
         createdApi.setGraviteeDefinitionVersion("1.0.0");
         createdApi.setId("my-beautiful-api");
-        doReturn(createdApi).when(apiDuplicatorService).createWithImportedDefinition(any(), any());
+        doReturn(createdApi)
+            .when(apiDuplicatorService)
+            .createWithImportedDefinition(
+                any(),
+                any(),
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment())
+            );
 
         final Response response = envTarget().path("import").request().post(Entity.json(apiDefinition));
         assertEquals(HttpStatusCode.OK_200, response.getStatus());
@@ -139,7 +147,14 @@ public class ApisResourceTest extends AbstractResourceTest {
         ApiEntity createdApi = new ApiEntity();
         createdApi.setGraviteeDefinitionVersion("2.0.0");
         createdApi.setId("my-beautiful-api");
-        doReturn(createdApi).when(apiDuplicatorService).createWithImportedDefinition(any(), any());
+        doReturn(createdApi)
+            .when(apiDuplicatorService)
+            .createWithImportedDefinition(
+                any(),
+                any(),
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment())
+            );
 
         final Response response = envTarget()
             .path("import")
@@ -159,7 +174,14 @@ public class ApisResourceTest extends AbstractResourceTest {
         ApiEntity createdApi = new ApiEntity();
         createdApi.setGraviteeDefinitionVersion("1.0.0");
         createdApi.setId("my-beautiful-api");
-        doReturn(createdApi).when(apiDuplicatorService).createWithImportedDefinition(any(), any());
+        doReturn(createdApi)
+            .when(apiDuplicatorService)
+            .createWithImportedDefinition(
+                any(),
+                any(),
+                eq(GraviteeContext.getCurrentOrganization()),
+                eq(GraviteeContext.getCurrentEnvironment())
+            );
 
         final Response response = envTarget()
             .path("import")

--- a/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PortalPagesResourceAdminTest.java
+++ b/gravitee-rest-api-management/gravitee-rest-api-management-rest/src/test/java/io/gravitee/rest/api/management/rest/resource/PortalPagesResourceAdminTest.java
@@ -18,6 +18,7 @@ package io.gravitee.rest.api.management.rest.resource;
 import static io.gravitee.common.http.HttpStatusCode.BAD_REQUEST_400;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.reset;
 
@@ -27,6 +28,7 @@ import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PageType;
 import io.gravitee.rest.api.model.UpdatePageEntity;
 import io.gravitee.rest.api.model.Visibility;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
@@ -104,8 +106,8 @@ public class PortalPagesResourceAdminTest extends AbstractResourceTest {
 
         PageEntity returnedPage = new PageEntity();
         returnedPage.setId("my-beautiful-page");
-        doReturn(returnedPage).when(pageService).createPage(any());
-        doReturn(0).when(pageService).findMaxPortalPageOrder();
+        doReturn(returnedPage).when(pageService).createPage(any(), eq(GraviteeContext.getCurrentEnvironment()));
+        doReturn(0).when(pageService).findMaxPortalPageOrder(eq(GraviteeContext.getCurrentEnvironment()));
 
         final Response response = envTarget().request().post(Entity.json(newPageEntity));
 

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResource.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResource.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.portal.rest.utils.HttpHeadersUtil;
 import io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper;
 import io.gravitee.rest.api.service.AccessControlService;
 import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -73,7 +74,11 @@ public class ApiPagesResource extends AbstractResource {
             final String acceptedLocale = HttpHeadersUtil.getFirstAcceptedLocaleName(acceptLang);
 
             Stream<Page> pageStream = pageService
-                .search(new PageQuery.Builder().api(apiId).homepage(homepage).published(true).build(), acceptedLocale)
+                .search(
+                    new PageQuery.Builder().api(apiId).homepage(homepage).published(true).build(),
+                    acceptedLocale,
+                    GraviteeContext.getCurrentEnvironment()
+                )
                 .stream()
                 .filter(accessControlService::canAccessPageFromPortal)
                 .map(pageMapper::convert)

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiResource.java
@@ -31,6 +31,7 @@ import io.gravitee.rest.api.portal.rest.security.RequirePortalAuth;
 import io.gravitee.rest.api.portal.rest.utils.HttpHeadersUtil;
 import io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.ApiNotFoundException;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -89,7 +90,7 @@ public class ApiResource extends AbstractResource {
 
             if (include.contains(INCLUDE_PAGES)) {
                 List<Page> pages = pageService
-                    .search(new PageQuery.Builder().api(apiId).published(true).build())
+                    .search(new PageQuery.Builder().api(apiId).published(true).build(), GraviteeContext.getCurrentEnvironment())
                     .stream()
                     .filter(page -> accessControlService.canAccessPageFromPortal(page))
                     .map(pageMapper::convert)
@@ -162,7 +163,11 @@ public class ApiResource extends AbstractResource {
         final String acceptedLocale = HttpHeadersUtil.getFirstAcceptedLocaleName(acceptLang);
         Map<String, List<CategorizedLinks>> apiLinks = new HashMap<>();
         pageService
-            .search(new PageQuery.Builder().api(apiId).type(PageType.SYSTEM_FOLDER).build(), acceptedLocale)
+            .search(
+                new PageQuery.Builder().api(apiId).type(PageType.SYSTEM_FOLDER).build(),
+                acceptedLocale,
+                GraviteeContext.getCurrentEnvironment()
+            )
             .stream()
             .filter(PageEntity::isPublished)
             .forEach(
@@ -181,7 +186,11 @@ public class ApiResource extends AbstractResource {
 
                     // for pages into folders
                     pageService
-                        .search(new PageQuery.Builder().api(apiId).parent(sysPage.getId()).build(), acceptedLocale)
+                        .search(
+                            new PageQuery.Builder().api(apiId).parent(sysPage.getId()).build(),
+                            acceptedLocale,
+                            GraviteeContext.getCurrentEnvironment()
+                        )
                         .stream()
                         .filter(PageEntity::isPublished)
                         .filter(p -> p.getType().equals("FOLDER"))
@@ -208,7 +217,11 @@ public class ApiResource extends AbstractResource {
 
     private List<Link> getLinksFromFolder(PageEntity folder, String apiId, String acceptedLocale) {
         return pageService
-            .search(new PageQuery.Builder().api(apiId).parent(folder.getId()).build(), acceptedLocale)
+            .search(
+                new PageQuery.Builder().api(apiId).parent(folder.getId()).build(),
+                acceptedLocale,
+                GraviteeContext.getCurrentEnvironment()
+            )
             .stream()
             .filter(accessControlService::canAccessPageFromPortal)
             .filter(p -> !PageType.FOLDER.name().equals(p.getType()) && !PageType.MARKDOWN_TEMPLATE.name().equals(p.getType()))

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ConfigurationResource.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ConfigurationResource.java
@@ -138,7 +138,7 @@ public class ConfigurationResource extends AbstractResource {
         final String acceptedLocale = HttpHeadersUtil.getFirstAcceptedLocaleName(acceptLang);
         Map<String, List<CategorizedLinks>> portalLinks = new HashMap<>();
         pageService
-            .search(new PageQuery.Builder().type(PageType.SYSTEM_FOLDER).build(), acceptedLocale)
+            .search(new PageQuery.Builder().type(PageType.SYSTEM_FOLDER).build(), acceptedLocale, GraviteeContext.getCurrentEnvironment())
             .stream()
             .filter(PageEntity::isPublished)
             .forEach(
@@ -157,7 +157,11 @@ public class ConfigurationResource extends AbstractResource {
 
                     // for pages into folders
                     pageService
-                        .search(new PageQuery.Builder().parent(systemFolder.getId()).build(), acceptedLocale)
+                        .search(
+                            new PageQuery.Builder().parent(systemFolder.getId()).build(),
+                            acceptedLocale,
+                            GraviteeContext.getCurrentEnvironment()
+                        )
                         .stream()
                         .filter(PageEntity::isPublished)
                         .filter(p -> p.getType().equals("FOLDER"))
@@ -184,7 +188,7 @@ public class ConfigurationResource extends AbstractResource {
 
     private List<Link> getLinksFromFolder(PageEntity folder, String acceptedLocale) {
         return pageService
-            .search(new PageQuery.Builder().parent(folder.getId()).build(), acceptedLocale)
+            .search(new PageQuery.Builder().parent(folder.getId()).build(), acceptedLocale, GraviteeContext.getCurrentEnvironment())
             .stream()
             .filter(
                 p -> {

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PagesResource.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/PagesResource.java
@@ -25,6 +25,7 @@ import io.gravitee.rest.api.portal.rest.utils.HttpHeadersUtil;
 import io.gravitee.rest.api.portal.rest.utils.PortalApiLinkHelper;
 import io.gravitee.rest.api.service.AccessControlService;
 import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -66,7 +67,11 @@ public class PagesResource extends AbstractResource {
     ) {
         final String acceptedLocale = HttpHeadersUtil.getFirstAcceptedLocaleName(acceptLang);
         Stream<Page> pageStream = pageService
-            .search(new PageQuery.Builder().homepage(homepage).published(true).build(), acceptedLocale)
+            .search(
+                new PageQuery.Builder().homepage(homepage).published(true).build(),
+                acceptedLocale,
+                GraviteeContext.getCurrentEnvironment()
+            )
             .stream()
             .filter(accessControlService::canAccessPageFromPortal)
             .map(pageMapper::convert)

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResourceTest.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResourceTest.java
@@ -19,8 +19,7 @@ import static io.gravitee.common.http.HttpStatusCode.NOT_FOUND_404;
 import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +28,7 @@ import io.gravitee.rest.api.model.PageType;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.portal.rest.model.*;
 import io.gravitee.rest.api.portal.rest.model.Error;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -59,7 +59,9 @@ public class ApiPagesResourceTest extends AbstractResourceTest {
 
         PageEntity markdownTemplate = new PageEntity();
         markdownTemplate.setType(PageType.MARKDOWN_TEMPLATE.name());
-        doReturn(Arrays.asList(new PageEntity(), markdownTemplate)).when(pageService).search(any(), isNull());
+        doReturn(Arrays.asList(new PageEntity(), markdownTemplate))
+            .when(pageService)
+            .search(any(), isNull(), eq(GraviteeContext.getCurrentEnvironment()));
 
         when(accessControlService.canAccessPageFromPortal(any(PageEntity.class)))
             .thenAnswer(

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceNotAuthenticatedTest.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiResourceNotAuthenticatedTest.java
@@ -19,6 +19,7 @@ import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +30,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.portal.rest.model.Api;
 import io.gravitee.rest.api.portal.rest.model.Page;
 import io.gravitee.rest.api.portal.rest.model.Plan;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Arrays;
@@ -104,7 +106,7 @@ public class ApiResourceNotAuthenticatedTest extends AbstractResourceTest {
         when(accessControlService.canAccessApiFromPortal(API)).thenReturn(true);
         when(accessControlService.canAccessApiFromPortal(mockApi)).thenReturn(true);
 
-        doReturn(Arrays.asList(new PageEntity())).when(pageService).search(any());
+        doReturn(Arrays.asList(new PageEntity())).when(pageService).search(any(), eq(GraviteeContext.getCurrentEnvironment()));
 
         PlanEntity plan1 = new PlanEntity();
         plan1.setId("A");

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ConfigurationResourceTest.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ConfigurationResourceTest.java
@@ -16,8 +16,7 @@
 package io.gravitee.rest.api.portal.rest.resource;
 
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -36,6 +35,7 @@ import io.gravitee.rest.api.model.settings.ConsoleSettingsEntity;
 import io.gravitee.rest.api.model.settings.PortalSettingsEntity;
 import io.gravitee.rest.api.portal.rest.model.*;
 import io.gravitee.rest.api.portal.rest.model.Link.ResourceTypeEnum;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.util.*;
 import javax.validation.Valid;
 import javax.ws.rs.core.Response;
@@ -119,7 +119,7 @@ public class ConfigurationResourceTest extends AbstractResourceTest {
         markdownTemplate.setName("MARKDOWN_TEMPLATE");
         markdownTemplate.setPublished(true);
 
-        when(pageService.search(any(PageQuery.class), isNull()))
+        when(pageService.search(any(PageQuery.class), isNull(), eq(GraviteeContext.getCurrentEnvironment())))
             .thenAnswer(
                 (Answer<List<PageEntity>>) invocation -> {
                     PageQuery pq = invocation.getArgument(0);

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PagesResourceTest.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/PagesResourceTest.java
@@ -19,8 +19,7 @@ import static io.gravitee.common.http.HttpStatusCode.OK_200;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -29,6 +28,7 @@ import io.gravitee.rest.api.model.PageType;
 import io.gravitee.rest.api.portal.rest.model.Page;
 import io.gravitee.rest.api.portal.rest.model.PageLinks;
 import io.gravitee.rest.api.portal.rest.model.PagesResponse;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -62,7 +62,9 @@ public class PagesResourceTest extends AbstractResourceTest {
         PageEntity markdownTemplatePage = new PageEntity();
         markdownTemplatePage.setPublished(true);
         markdownTemplatePage.setType(PageType.MARKDOWN_TEMPLATE.name());
-        doReturn(Arrays.asList(publishedPage, markdownTemplatePage)).when(pageService).search(any(), isNull());
+        doReturn(Arrays.asList(publishedPage, markdownTemplatePage))
+            .when(pageService)
+            .search(any(), isNull(), eq(GraviteeContext.getCurrentEnvironment()));
 
         when(accessControlService.canAccessPageFromPortal(any(PageEntity.class)))
             .thenAnswer(
@@ -87,7 +89,7 @@ public class PagesResourceTest extends AbstractResourceTest {
     public void shouldGetNoPageIfNotAuthorizeAndPublishedPageAndNotSystemFolder() {
         PageEntity publishedPage = new PageEntity();
         publishedPage.setPublished(true);
-        doReturn(singletonList(publishedPage)).when(pageService).search(any(), isNull());
+        doReturn(singletonList(publishedPage)).when(pageService).search(any(), isNull(), eq(GraviteeContext.getCurrentEnvironment()));
 
         Response response = target().request().get();
         assertEquals(OK_200, response.getStatus());
@@ -104,7 +106,7 @@ public class PagesResourceTest extends AbstractResourceTest {
         PageEntity publishedPage = new PageEntity();
         publishedPage.setPublished(true);
         publishedPage.setType("SYSTEM_FOLDER");
-        doReturn(singletonList(publishedPage)).when(pageService).search(any(), isNull());
+        doReturn(singletonList(publishedPage)).when(pageService).search(any(), isNull(), eq(GraviteeContext.getCurrentEnvironment()));
 
         Response response = target().request().get();
         assertEquals(OK_200, response.getStatus());
@@ -118,7 +120,7 @@ public class PagesResourceTest extends AbstractResourceTest {
 
     @Test
     public void shouldGetNoPageIfAuthorizeAndNotPublished() {
-        doReturn(Collections.emptyList()).when(pageService).search(any(), isNull());
+        doReturn(Collections.emptyList()).when(pageService).search(any(), isNull(), eq(GraviteeContext.getCurrentEnvironment()));
 
         Response response = target().request().get();
         assertEquals(OK_200, response.getStatus());

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiDuplicatorService.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/ApiDuplicatorService.java
@@ -19,11 +19,17 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.DuplicateApiEntity;
 
 public interface ApiDuplicatorService {
-    ApiEntity createWithImportedDefinition(String apiDefinitionOrURL, String userId);
+    ApiEntity createWithImportedDefinition(String apiDefinitionOrURL, String userId, String organizationId, String environmentId);
 
-    ApiEntity duplicate(ApiEntity apiEntity, DuplicateApiEntity duplicateApiEntity);
+    ApiEntity duplicate(ApiEntity apiEntity, DuplicateApiEntity duplicateApiEntity, String organizationId, String environmentId);
 
     String exportAsJson(String apiId, String exportVersion, String... filteredFields);
 
-    ApiEntity updateWithImportedDefinition(String apiId, String apiDefinitionOrURL, String userId);
+    ApiEntity updateWithImportedDefinition(
+        String apiId,
+        String apiDefinitionOrURL,
+        String userId,
+        String organizationId,
+        String environmentId
+    );
 }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/PageService.java
@@ -35,19 +35,19 @@ public interface PageService {
 
     PageEntity findById(String pageId, String acceptedLocale);
 
-    List<PageEntity> search(PageQuery query);
+    List<PageEntity> search(PageQuery query, String environmentId);
 
-    List<PageEntity> search(PageQuery query, boolean withTranslations);
+    List<PageEntity> search(PageQuery query, boolean withTranslations, String environmentId);
 
-    List<PageEntity> search(PageQuery query, String acceptedLocale);
+    List<PageEntity> search(PageQuery query, String acceptedLocale, String environmentId);
 
     void transformSwagger(PageEntity pageEntity);
 
     void transformSwagger(PageEntity pageEntity, String apiId);
 
-    PageEntity createPage(String apiId, NewPageEntity page);
+    PageEntity createPage(String apiId, NewPageEntity page, String environmentId);
 
-    PageEntity createPage(NewPageEntity page);
+    PageEntity createPage(NewPageEntity page, String environmentId);
 
     PageEntity update(String pageId, UpdatePageEntity updatePageEntity);
 
@@ -55,25 +55,25 @@ public interface PageService {
 
     void delete(String pageId);
 
-    void deleteAllByApi(String apiId);
+    void deleteAllByApi(String apiId, String environmentId);
 
     int findMaxApiPageOrderByApi(String apiId);
 
-    int findMaxPortalPageOrder();
+    int findMaxPortalPageOrder(String referenceId);
 
-    void fetchAll(PageQuery query, String contributor);
+    void fetchAll(PageQuery query, String contributor, String currentEnvironment);
 
-    long execAutoFetch();
+    long execAutoFetch(String environmentId);
 
     PageEntity fetch(String pageId, String contributor);
 
-    List<PageEntity> importFiles(ImportPageEntity pageEntity);
+    List<PageEntity> importFiles(ImportPageEntity pageEntity, String environmentId);
 
-    List<PageEntity> importFiles(String apiId, ImportPageEntity pageEntity);
+    List<PageEntity> importFiles(String apiId, ImportPageEntity pageEntity, String environmentId);
 
     void transformWithTemplate(PageEntity pageEntity, String api);
 
-    PageEntity create(String apiId, PageEntity pageEntity);
+    PageEntity create(String apiId, PageEntity pageEntity, String environmentId);
 
     List<String> validateSafeContent(PageEntity pageEntity, String apiId);
 
@@ -81,7 +81,7 @@ public interface PageService {
 
     PageEntity createSystemFolder(String apiId, SystemFolderType systemFolderType, int order, String environmentId);
 
-    PageEntity createWithDefinition(String apiId, String toString);
+    PageEntity createWithDefinition(String apiId, String toString, String environmentId);
 
     /**
      * Check if the page is used as GeneralCondition by an active Plan for the given ApiID

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -510,7 +510,10 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         boolean isForCreation
     ) {
         if (swaggerDescriptor != null && swaggerDescriptor.isWithDocumentation()) {
-            List<PageEntity> apiDocs = pageService.search(new PageQuery.Builder().api(api.getId()).type(PageType.SWAGGER).build());
+            List<PageEntity> apiDocs = pageService.search(
+                new PageQuery.Builder().api(api.getId()).type(PageType.SWAGGER).build(),
+                GraviteeContext.getCurrentEnvironment()
+            );
 
             if (isForCreation || (apiDocs == null || apiDocs.isEmpty())) {
                 final NewPageEntity page = new NewPageEntity();
@@ -525,7 +528,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                     source.setType("http-fetcher");
                     source.setConfiguration(objectMapper.convertValue(singletonMap("url", swaggerDescriptor.getPayload()), JsonNode.class));
                 }
-                pageService.createPage(api.getId(), page);
+                pageService.createPage(api.getId(), page, GraviteeContext.getCurrentEnvironment());
             } else if (apiDocs.size() == 1) {
                 PageEntity pageToUpdate = apiDocs.get(0);
                 final UpdatePageEntity page = new UpdatePageEntity();
@@ -655,7 +658,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
         asideSystemFolder.setPublished(true);
         asideSystemFolder.setType(PageType.SYSTEM_FOLDER);
         asideSystemFolder.setVisibility(io.gravitee.rest.api.model.Visibility.PUBLIC);
-        pageService.createPage(apiId, asideSystemFolder);
+        pageService.createPage(apiId, asideSystemFolder, GraviteeContext.getCurrentEnvironment());
     }
 
     private void checkEndpointsName(UpdateApiEntity api) {
@@ -1734,7 +1737,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
                 eventService.create(EventType.UNPUBLISH_API, null, properties);
 
                 // Delete pages
-                pageService.deleteAllByApi(apiId);
+                pageService.deleteAllByApi(apiId, GraviteeContext.getCurrentEnvironment());
 
                 // Delete top API
                 topApiService.delete(apiId);

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
@@ -264,11 +264,24 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
                 // FIXME: All the methods should take then env id as input instead of relying on GraviteeContext.getCurrentEnv
                 GraviteeContext.setCurrentEnvironment(environment.getId());
                 if (shouldCreate) {
-                    promoted = apiDuplicatorService.createWithImportedDefinition(existing.getApiDefinition(), user);
+                    promoted =
+                        apiDuplicatorService.createWithImportedDefinition(
+                            existing.getApiDefinition(),
+                            user,
+                            GraviteeContext.getCurrentOrganization(),
+                            GraviteeContext.getCurrentEnvironment()
+                        );
                 } else {
                     PromotionEntity lastAcceptedPromotion = previousPromotions.get(0);
                     final ApiEntity existingApi = apiService.findById(lastAcceptedPromotion.getTargetApiId());
-                    promoted = apiDuplicatorService.updateWithImportedDefinition(existingApi.getId(), existing.getApiDefinition(), user);
+                    promoted =
+                        apiDuplicatorService.updateWithImportedDefinition(
+                            existingApi.getId(),
+                            existing.getApiDefinition(),
+                            user,
+                            GraviteeContext.getCurrentOrganization(),
+                            GraviteeContext.getCurrentEnvironment()
+                        );
                 }
                 existing.setTargetApiId(promoted.getId());
             }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DocumentationSystemFolderUpgrader.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/DocumentationSystemFolderUpgrader.java
@@ -53,7 +53,7 @@ public class DocumentationSystemFolderUpgrader implements Upgrader, Ordered {
     public boolean upgrade() {
         PageQuery query = new PageQuery.Builder().type(PageType.SYSTEM_FOLDER).build();
         // searching for system folders.
-        if (pageService.search(query).isEmpty()) {
+        if (pageService.search(query, GraviteeContext.getCurrentEnvironment()).isEmpty()) {
             logger.info("No system folders found. Add system folders in documentation, for portal and each API.");
 
             // Portal documentation
@@ -64,7 +64,7 @@ public class DocumentationSystemFolderUpgrader implements Upgrader, Ordered {
 
             // Create link to existing documentation in footer
             List<PageEntity> pagesToLink = pageService
-                .search(new PageQuery.Builder().homepage(false).rootParent(true).build())
+                .search(new PageQuery.Builder().homepage(false).rootParent(true).build(), GraviteeContext.getCurrentEnvironment())
                 .stream()
                 .filter(p -> PageType.SWAGGER.name().equals(p.getType()) || PageType.MARKDOWN.name().equals(p.getType()))
                 .collect(Collectors.toList());
@@ -97,7 +97,7 @@ public class DocumentationSystemFolderUpgrader implements Upgrader, Ordered {
         newFolder.setParentId(parentId);
         newFolder.setVisibility(Visibility.PUBLIC);
 
-        return pageService.createPage(newFolder);
+        return pageService.createPage(newFolder, GraviteeContext.getCurrentEnvironment());
     }
 
     private void createLink(String parentId, String name, String resourceRef, String resourceType, Boolean isFolder, Boolean inherit) {
@@ -120,7 +120,7 @@ public class DocumentationSystemFolderUpgrader implements Upgrader, Ordered {
 
         newLink.setConfiguration(configuration);
 
-        pageService.createPage(newLink);
+        pageService.createPage(newLink, GraviteeContext.getCurrentEnvironment());
     }
 
     @Override

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/upgrade/SearchIndexUpgrader.java
@@ -83,7 +83,8 @@ public class SearchIndexUpgrader implements Upgrader, Ordered {
                                             // Pages
                                             List<PageEntity> apiPages = pageService.search(
                                                 new PageQuery.Builder().api(apiEntity.getId()).published(true).build(),
-                                                true
+                                                true,
+                                                GraviteeContext.getCurrentEnvironment()
                                             );
                                             apiPages.forEach(
                                                 page -> {

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/jackson/ser/api/ApiSerializer.java
@@ -26,6 +26,7 @@ import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.documentation.PageQuery;
 import io.gravitee.rest.api.service.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import java.io.IOException;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -176,7 +177,7 @@ public abstract class ApiSerializer extends StdSerializer<ApiEntity> {
             if (!filteredFieldsList.contains("pages")) {
                 List<PageEntity> pages = applicationContext
                     .getBean(PageService.class)
-                    .search(new PageQuery.Builder().api(apiEntity.getId()).build(), true);
+                    .search(new PageQuery.Builder().api(apiEntity.getId()).build(), true, GraviteeContext.getCurrentEnvironment());
 
                 if (this.version().getVersion().startsWith("1.")) {
                     pages =

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricFunctionalDocumentation.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricFunctionalDocumentation.java
@@ -20,6 +20,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.documentation.PageQuery;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -38,6 +39,14 @@ public class ApiQualityMetricFunctionalDocumentation implements ApiQualityMetric
 
     @Override
     public boolean isValid(ApiEntity api) {
-        return pageService.search(new PageQuery.Builder().api(api.getId()).published(true).type(PageType.MARKDOWN).build()).size() > 0L;
+        return (
+            pageService
+                .search(
+                    new PageQuery.Builder().api(api.getId()).published(true).type(PageType.MARKDOWN).build(),
+                    GraviteeContext.getCurrentEnvironment()
+                )
+                .size() >
+            0L
+        );
     }
 }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricTechnicalDocumentation.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/quality/ApiQualityMetricTechnicalDocumentation.java
@@ -20,6 +20,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.documentation.PageQuery;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
@@ -38,6 +39,14 @@ public class ApiQualityMetricTechnicalDocumentation implements ApiQualityMetric 
 
     @Override
     public boolean isValid(ApiEntity api) {
-        return pageService.search(new PageQuery.Builder().api(api.getId()).published(true).type(PageType.SWAGGER).build()).size() > 0L;
+        return (
+            pageService
+                .search(
+                    new PageQuery.Builder().api(api.getId()).published(true).type(PageType.SWAGGER).build(),
+                    GraviteeContext.getCurrentEnvironment()
+                )
+                .size() >
+            0L
+        );
     }
 }

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_CreateWithDefinitionTest.java
@@ -26,6 +26,7 @@ import io.gravitee.repository.management.model.Api;
 import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
 import io.gravitee.rest.api.service.impl.ApiDuplicatorServiceImpl;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
@@ -171,12 +172,17 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         memberEntity.setRoles(Collections.singletonList(poRoleEntity));
         when(userService.findBySource(user.getSource(), user.getSourceId(), false)).thenReturn(user);
         when(userService.findById(memberEntity.getId())).thenReturn(admin);
-        when(pageService.createWithDefinition(any(), any())).thenReturn(new PageEntity());
+        when(pageService.createWithDefinition(any(), any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(new PageEntity());
 
-        apiDuplicatorService.createWithImportedDefinition(toBeImport, "admin");
+        apiDuplicatorService.createWithImportedDefinition(
+            toBeImport,
+            "admin",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
-        verify(pageService, times(2)).createWithDefinition(eq(API_ID), anyString());
+        verify(pageService, times(2)).createWithDefinition(eq(API_ID), anyString(), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(MembershipReferenceType.API, API_ID, MembershipMemberType.USER, user.getId(), "API_OWNER");
     }
@@ -224,10 +230,15 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         memberEntity.setId(admin.getId());
         memberEntity.setRoles(Collections.singletonList(poRoleEntity));
 
-        apiDuplicatorService.createWithImportedDefinition(toBeImport, "admin");
+        apiDuplicatorService.createWithImportedDefinition(
+            toBeImport,
+            "admin",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
-        verify(pageService, times(1)).createPage(eq(API_ID), any(NewPageEntity.class));
+        verify(pageService, times(1)).createPage(eq(API_ID), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, times(1))
             .addRoleToMemberOnReference(MembershipReferenceType.API, API_ID, MembershipMemberType.USER, user.getId(), "API_OWNER");
         verify(membershipService, never()).transferApiOwnership(any(), any(), any());
@@ -251,12 +262,17 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         user.setId("user");
         user.setSource(SOURCE);
         user.setSourceId("ref-user");
-        when(pageService.createWithDefinition(any(), any())).thenReturn(new PageEntity());
+        when(pageService.createWithDefinition(any(), any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(new PageEntity());
 
-        apiDuplicatorService.createWithImportedDefinition(toBeImport, "admin");
+        apiDuplicatorService.createWithImportedDefinition(
+            toBeImport,
+            "admin",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
-        verify(pageService, times(2)).createWithDefinition(eq(API_ID), anyString());
+        verify(pageService, times(2)).createWithDefinition(eq(API_ID), anyString(), eq(GraviteeContext.getCurrentEnvironment()));
     }
 
     @Test
@@ -278,10 +294,15 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         user.setSource(SOURCE);
         user.setSourceId(API_ID);
 
-        apiDuplicatorService.createWithImportedDefinition(toBeImport, "admin");
+        apiDuplicatorService.createWithImportedDefinition(
+            toBeImport,
+            "admin",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
-        verify(pageService, times(1)).createPage(any(), any(NewPageEntity.class));
+        verify(pageService, times(1)).createPage(any(), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
     }
 
     @Test
@@ -303,10 +324,15 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         user.setSource(SOURCE);
         user.setSourceId(API_ID);
 
-        apiDuplicatorService.createWithImportedDefinition(toBeImport, "admin");
+        apiDuplicatorService.createWithImportedDefinition(
+            toBeImport,
+            "admin",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
-        verify(pageService, times(1)).createPage(any(), any(NewPageEntity.class));
+        verify(pageService, times(1)).createPage(any(), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
     }
 
     @Test
@@ -328,11 +354,16 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         user.setSource(SOURCE);
         user.setSourceId(API_ID);
 
-        apiDuplicatorService.createWithImportedDefinition(toBeImport, "admin");
+        apiDuplicatorService.createWithImportedDefinition(
+            toBeImport,
+            "admin",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
 
-        verify(pageService, times(1)).createPage(any(), any(NewPageEntity.class));
+        verify(pageService, times(1)).createPage(any(), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
     }
 
     @Test
@@ -351,10 +382,15 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         admin.setSourceId(API_ID);
         when(planService.findById(anyString())).thenThrow(PlanNotFoundException.class);
 
-        apiDuplicatorService.createWithImportedDefinition(toBeImport, "admin");
+        apiDuplicatorService.createWithImportedDefinition(
+            toBeImport,
+            "admin",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
-        verify(pageService, times(1)).createPage(eq(API_ID), any(NewPageEntity.class));
+        verify(pageService, times(1)).createPage(eq(API_ID), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
     }
 
     @Test
@@ -377,7 +413,12 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         user.setSourceId(API_ID);
         when(planService.findById(anyString())).thenThrow(PlanNotFoundException.class);
 
-        apiDuplicatorService.createWithImportedDefinition(toBeImport, "admin");
+        apiDuplicatorService.createWithImportedDefinition(
+            toBeImport,
+            "admin",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
 
@@ -399,7 +440,12 @@ public class ApiDuplicatorService_CreateWithDefinitionTest {
         admin.setSource(SOURCE);
         admin.setSourceId(API_ID);
 
-        apiDuplicatorService.createWithImportedDefinition(toBeImport, "admin");
+        apiDuplicatorService.createWithImportedDefinition(
+            toBeImport,
+            "admin",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
         verify(apiService, times(1)).createWithApiDefinition(any(), eq("admin"), any());
 

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_ExportAsJsonTestSetup.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_ExportAsJsonTestSetup.java
@@ -247,7 +247,7 @@ public class ApiDuplicatorService_ExportAsJsonTestSetup {
         asciidocPage.setType(PageType.ASCIIDOC.toString());
         asciidocPage.setContent("Read the asciidoc");
         asciidocPage.setVisibility(Visibility.PUBLIC);
-        when(pageService.search(any(), eq(true)))
+        when(pageService.search(any(), eq(true), eq(GraviteeContext.getCurrentEnvironment())))
             .thenReturn(
                 Arrays.asList(folder, markdownPage, swaggerPage, asideFolder, linkPage, translationPage, markdownTemplatePage, asciidocPage)
             );

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_UpdateWithDefinitionTest.java
@@ -29,6 +29,7 @@ import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.model.permissions.SystemRole;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.ApiDuplicatorServiceImpl;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import java.io.IOException;
@@ -40,7 +41,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -184,7 +184,13 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         when(membershipService.addRoleToMemberOnReference(any(), any(), any(), any(), any())).thenReturn(memberEntity);
         when(userService.findBySource(user.getSource(), user.getSourceId(), false)).thenReturn(user);
 
-        apiDuplicatorService.updateWithImportedDefinition(apiEntity.getId(), toBeImport, "import");
+        apiDuplicatorService.updateWithImportedDefinition(
+            apiEntity.getId(),
+            toBeImport,
+            "import",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
         verify(pageService, times(2)).update(any(), any(UpdatePageEntity.class));
         verify(membershipService, never())
@@ -259,9 +265,15 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         when(membershipService.getMembersByReference(MembershipReferenceType.API, API_ID)).thenReturn(new HashSet(Arrays.asList(po)));
         when(userService.findById(admin.getId())).thenReturn(admin);
 
-        apiDuplicatorService.updateWithImportedDefinition(apiEntity.getId(), toBeImport, "import");
+        apiDuplicatorService.updateWithImportedDefinition(
+            apiEntity.getId(),
+            toBeImport,
+            "import",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
-        verify(pageService, never()).createPage(eq(API_ID), any(NewPageEntity.class));
+        verify(pageService, never()).createPage(eq(API_ID), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, never())
             .addRoleToMemberOnReference(MembershipReferenceType.API, API_ID, MembershipMemberType.USER, user.getId(), "API_PRIMARY_OWNER");
         verify(membershipService, times(1))
@@ -287,9 +299,15 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         when(userService.findById(admin.getId())).thenReturn(admin);
         when(userService.findById(user.getId())).thenReturn(user);
 
-        apiDuplicatorService.updateWithImportedDefinition(apiEntity.getId(), toBeImport, "import");
+        apiDuplicatorService.updateWithImportedDefinition(
+            apiEntity.getId(),
+            toBeImport,
+            "import",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
-        verify(pageService, never()).createPage(eq(API_ID), any(NewPageEntity.class));
+        verify(pageService, never()).createPage(eq(API_ID), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, never())
             .addRoleToMemberOnReference(
                 new MembershipService.MembershipReference(MembershipReferenceType.API, API_ID),
@@ -322,9 +340,15 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         when(userService.findById(admin.getId())).thenReturn(admin);
         when(userService.findById(user.getId())).thenReturn(user);
 
-        apiDuplicatorService.updateWithImportedDefinition(apiEntity.getId(), toBeImport, "import");
+        apiDuplicatorService.updateWithImportedDefinition(
+            apiEntity.getId(),
+            toBeImport,
+            "import",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
-        verify(pageService, never()).createPage(eq(API_ID), any(NewPageEntity.class));
+        verify(pageService, never()).createPage(eq(API_ID), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, never())
             .addRoleToMemberOnReference(
                 new MembershipService.MembershipReference(MembershipReferenceType.API, API_ID),
@@ -360,9 +384,15 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         po.setReferenceType(MembershipReferenceType.API);
         po.setRoles(Collections.singletonList(poRole));
 
-        apiDuplicatorService.updateWithImportedDefinition(apiEntity.getId(), toBeImport, null);
+        apiDuplicatorService.updateWithImportedDefinition(
+            apiEntity.getId(),
+            toBeImport,
+            null,
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
-        verify(pageService, times(2)).createPage(eq(API_ID), any(NewPageEntity.class));
+        verify(pageService, times(2)).createPage(eq(API_ID), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, never()).addRoleToMemberOnReference(any(), any(), any());
         verify(apiService, times(1)).update(eq(API_ID), any(), anyBoolean());
         verify(apiService, never()).create(any(), any());
@@ -381,9 +411,15 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         RoleEntity poRole = new RoleEntity();
         poRole.setId("API_PRIMARY_OWNER");
 
-        apiDuplicatorService.updateWithImportedDefinition(apiEntity.getId(), toBeImport, null);
+        apiDuplicatorService.updateWithImportedDefinition(
+            apiEntity.getId(),
+            toBeImport,
+            null,
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
-        verify(pageService, never()).createPage(eq(API_ID), any(NewPageEntity.class));
+        verify(pageService, never()).createPage(eq(API_ID), any(NewPageEntity.class), eq(GraviteeContext.getCurrentEnvironment()));
         verify(membershipService, never()).addRoleToMemberOnReference(any(), any(), any());
         verify(apiService, times(1)).update(eq(API_ID), any(), anyBoolean());
         verify(apiService, never()).create(any(), any());
@@ -403,7 +439,13 @@ public class ApiDuplicatorService_UpdateWithDefinitionTest {
         plan2.setId("plan-id2");
         when(planService.findById(plan2.getId())).thenReturn(plan2);
 
-        apiDuplicatorService.updateWithImportedDefinition(apiEntity.getId(), toBeImport, "import");
+        apiDuplicatorService.updateWithImportedDefinition(
+            apiEntity.getId(),
+            toBeImport,
+            "import",
+            GraviteeContext.getCurrentOrganization(),
+            GraviteeContext.getCurrentEnvironment()
+        );
 
         verify(planService, times(2)).update(any(UpdatePlanEntity.class));
         verify(apiService, times(1)).update(eq(API_ID), any(), anyBoolean());

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_gRPC_ExportAsJsonTestSetup.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiDuplicatorService_gRPC_ExportAsJsonTestSetup.java
@@ -265,7 +265,7 @@ public class ApiDuplicatorService_gRPC_ExportAsJsonTestSetup {
         asciidocPage.setType(PageType.ASCIIDOC.toString());
         asciidocPage.setContent("Read the asciidoc");
         asciidocPage.setVisibility(Visibility.PUBLIC);
-        when(pageService.search(any(), eq(true)))
+        when(pageService.search(any(), eq(true), eq(GraviteeContext.getCurrentEnvironment())))
             .thenReturn(
                 Arrays.asList(folder, markdownPage, swaggerPage, asideFolder, linkPage, translationPage, markdownTemplatePage, asciidocPage)
             );

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricFunctionalDocumentationTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricFunctionalDocumentationTest.java
@@ -18,12 +18,13 @@ package io.gravitee.rest.api.service;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.quality.ApiQualityMetricFunctionalDocumentation;
 import java.util.Collections;
 import org.junit.Test;
@@ -50,7 +51,7 @@ public class ApiQualityMetricFunctionalDocumentationTest {
     @Test
     public void shouldBeValidWithMarkdownPublished() {
         PageEntity item = mock(PageEntity.class);
-        when(mockPageService.search(any())).thenReturn(Collections.singletonList(item));
+        when(mockPageService.search(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Collections.singletonList(item));
         ApiEntity api = mock(ApiEntity.class);
         when(api.getId()).thenReturn(API_ID);
 
@@ -61,7 +62,7 @@ public class ApiQualityMetricFunctionalDocumentationTest {
 
     @Test
     public void shouldNotBeValidWithEmptyList() {
-        when(mockPageService.search(any())).thenReturn(Collections.emptyList());
+        when(mockPageService.search(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Collections.emptyList());
         ApiEntity api = mock(ApiEntity.class);
         when(api.getId()).thenReturn(API_ID);
 

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricTechnicalDocumentationTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/ApiQualityMetricTechnicalDocumentationTest.java
@@ -18,13 +18,13 @@ package io.gravitee.rest.api.service;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.gravitee.rest.api.model.PageEntity;
-import io.gravitee.rest.api.model.PageType;
 import io.gravitee.rest.api.model.api.ApiEntity;
-import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.quality.ApiQualityMetricTechnicalDocumentation;
 import java.util.Collections;
 import org.junit.Test;
@@ -51,7 +51,7 @@ public class ApiQualityMetricTechnicalDocumentationTest {
     @Test
     public void shouldBeValidWithSwaggerPublished() {
         PageEntity item = mock(PageEntity.class);
-        when(mockPageService.search(any())).thenReturn(Collections.singletonList(item));
+        when(mockPageService.search(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Collections.singletonList(item));
         ApiEntity api = mock(ApiEntity.class);
         when(api.getId()).thenReturn(API_ID);
 
@@ -62,7 +62,7 @@ public class ApiQualityMetricTechnicalDocumentationTest {
 
     @Test
     public void shouldNotBeValidWithEmptyList() {
-        when(mockPageService.search(any())).thenReturn(Collections.emptyList());
+        when(mockPageService.search(any(), eq(GraviteeContext.getCurrentEnvironment()))).thenReturn(Collections.emptyList());
         ApiEntity api = mock(ApiEntity.class);
         when(api.getId()).thenReturn(API_ID);
 

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_AutoFetchTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_AutoFetchTest.java
@@ -28,6 +28,7 @@ import io.gravitee.repository.management.model.PageReferenceType;
 import io.gravitee.repository.management.model.PageSource;
 import io.gravitee.rest.api.fetcher.FetcherConfigurationFactory;
 import io.gravitee.rest.api.model.PageType;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.impl.GraviteeDescriptorServiceImpl;
 import io.gravitee.rest.api.service.impl.PageServiceImpl;
 import io.gravitee.rest.api.service.search.SearchEngineService;
@@ -35,7 +36,6 @@ import io.gravitee.rest.api.service.spring.ImportConfiguration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
 import org.junit.Test;
@@ -99,7 +99,7 @@ public class PageService_AutoFetchTest {
         when(mockPage.getSource()).thenReturn(null);
         when(pageRepository.search(any())).thenReturn(Arrays.asList(mockPage));
 
-        long pages = pageService.execAutoFetch();
+        long pages = pageService.execAutoFetch(GraviteeContext.getCurrentEnvironment());
         assertEquals(0, pages);
 
         verify(pageRepository, times(0)).update(any());
@@ -126,7 +126,7 @@ public class PageService_AutoFetchTest {
         AutowireCapableBeanFactory mockAutowireCapableBeanFactory = mock(AutowireCapableBeanFactory.class);
         when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(mockAutowireCapableBeanFactory);
 
-        long pages = pageService.execAutoFetch();
+        long pages = pageService.execAutoFetch(GraviteeContext.getCurrentEnvironment());
         assertEquals(0, pages);
 
         verify(pageRepository, times(0)).update(any());
@@ -159,7 +159,7 @@ public class PageService_AutoFetchTest {
         AutowireCapableBeanFactory mockAutowireCapableBeanFactory = mock(AutowireCapableBeanFactory.class);
         when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(mockAutowireCapableBeanFactory);
 
-        long pages = pageService.execAutoFetch();
+        long pages = pageService.execAutoFetch(GraviteeContext.getCurrentEnvironment());
         assertEquals(1, pages);
 
         verify(pageRepository, times(1)).update(any());
@@ -188,7 +188,7 @@ public class PageService_AutoFetchTest {
         when(applicationContext.getAutowireCapableBeanFactory()).thenReturn(mockAutowireCapableBeanFactory);
         PageService_MockSinglePageFetcherConfiguration.forceCronValue("* 10 * * * *");
 
-        long pages = pageService.execAutoFetch();
+        long pages = pageService.execAutoFetch(GraviteeContext.getCurrentEnvironment());
         assertEquals(0, pages);
 
         verify(pageRepository, times(0)).update(any());
@@ -234,7 +234,7 @@ public class PageService_AutoFetchTest {
         when(graviteeDescriptorService.descriptorName()).thenReturn(".gravitee.json");
         when(graviteeDescriptorService.read(anyString())).thenCallRealMethod();
 
-        pageService.execAutoFetch();
+        pageService.execAutoFetch(GraviteeContext.getCurrentEnvironment());
         verify(pageRepository, times(6)).update(any());
     }
 }

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_CreateTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_CreateTest.java
@@ -32,6 +32,7 @@ import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.model.Page;
 import io.gravitee.repository.management.model.PageReferenceType;
 import io.gravitee.rest.api.model.*;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.PageServiceImpl;
 import io.gravitee.rest.api.service.notification.NotificationTemplateService;
@@ -126,7 +127,7 @@ public class PageService_CreateTest {
         when(newPage.getType()).thenReturn(PageType.SWAGGER);
         when(newPage.getVisibility()).thenReturn(Visibility.PUBLIC);
 
-        final PageEntity createdPage = pageService.createPage(API_ID, newPage);
+        final PageEntity createdPage = pageService.createPage(API_ID, newPage, GraviteeContext.getCurrentEnvironment());
 
         verify(pageRepository)
             .create(
@@ -165,7 +166,7 @@ public class PageService_CreateTest {
 
         when(pageRepository.create(any(Page.class))).thenThrow(TechnicalException.class);
 
-        pageService.createPage(API_ID, newPage);
+        pageService.createPage(API_ID, newPage, GraviteeContext.getCurrentEnvironment());
 
         verify(pageRepository, never()).create(any());
     }
@@ -187,7 +188,7 @@ public class PageService_CreateTest {
         newFolder.setType(PageType.FOLDER);
         newFolder.setParentId("FOLD_IN_SYS");
 
-        pageService.createPage(newFolder);
+        pageService.createPage(newFolder, GraviteeContext.getCurrentEnvironment());
     }
 
     @Test
@@ -209,7 +210,7 @@ public class PageService_CreateTest {
         createdPage.setVisibility("PUBLIC");
         doReturn(createdPage).when(pageRepository).create(any());
 
-        final PageEntity createdFolder = pageService.createPage(newFolder);
+        final PageEntity createdFolder = pageService.createPage(newFolder, GraviteeContext.getCurrentEnvironment());
         assertNotNull(createdFolder);
 
         verify(pageRevisionService, times(0)).create(any());
@@ -226,7 +227,7 @@ public class PageService_CreateTest {
         newFolder.setType(PageType.SWAGGER);
         newFolder.setParentId("SYS");
 
-        pageService.createPage(newFolder);
+        pageService.createPage(newFolder, GraviteeContext.getCurrentEnvironment());
     }
 
     @Test(expected = PageActionException.class)
@@ -240,7 +241,7 @@ public class PageService_CreateTest {
         newFolder.setType(PageType.MARKDOWN);
         newFolder.setParentId("SYS");
 
-        pageService.createPage(newFolder);
+        pageService.createPage(newFolder, GraviteeContext.getCurrentEnvironment());
     }
 
     @Test(expected = PageActionException.class)
@@ -259,7 +260,7 @@ public class PageService_CreateTest {
         newLink.setConfiguration(conf);
         newLink.setContent("SYS");
 
-        pageService.createPage(newLink);
+        pageService.createPage(newLink, GraviteeContext.getCurrentEnvironment());
     }
 
     @Test(expected = PageActionException.class)
@@ -284,7 +285,7 @@ public class PageService_CreateTest {
         newLink.setConfiguration(conf);
         newLink.setContent("FOLD_IN_SYS");
 
-        pageService.createPage(newLink);
+        pageService.createPage(newLink, GraviteeContext.getCurrentEnvironment());
     }
 
     @Test
@@ -306,7 +307,7 @@ public class PageService_CreateTest {
         createdPage.setVisibility("PUBLIC");
         doReturn(createdPage).when(pageRepository).create(any());
 
-        pageService.createPage(newFolder);
+        pageService.createPage(newFolder, GraviteeContext.getCurrentEnvironment());
         verify(pageRepository).create(argThat(p -> p.isPublished() == true));
         // do not create revision for Link
         verify(pageRevisionService, times(0)).create(any());
@@ -338,7 +339,7 @@ public class PageService_CreateTest {
         createdPage.setVisibility("PUBLIC");
         doReturn(createdPage).when(pageRepository).create(any());
 
-        pageService.createPage(newLink);
+        pageService.createPage(newLink, GraviteeContext.getCurrentEnvironment());
         verify(pageRepository).create(argThat(p -> p.isPublished() == true));
         // do not create revision for Link
         verify(pageRevisionService, times(0)).create(any());
@@ -349,7 +350,7 @@ public class PageService_CreateTest {
         NewPageEntity newTranslation = new NewPageEntity();
         newTranslation.setType(PageType.TRANSLATION);
 
-        pageService.createPage(newTranslation);
+        pageService.createPage(newTranslation, GraviteeContext.getCurrentEnvironment());
     }
 
     @Test(expected = PageActionException.class)
@@ -358,7 +359,7 @@ public class PageService_CreateTest {
         newTranslation.setType(PageType.TRANSLATION);
         newTranslation.setParentId("FOLDER");
 
-        pageService.createPage(newTranslation);
+        pageService.createPage(newTranslation, GraviteeContext.getCurrentEnvironment());
     }
 
     @Test(expected = PageActionException.class)
@@ -370,7 +371,7 @@ public class PageService_CreateTest {
         Map<String, String> conf = new HashMap<>();
         newTranslation.setConfiguration(conf);
 
-        pageService.createPage(newTranslation);
+        pageService.createPage(newTranslation, GraviteeContext.getCurrentEnvironment());
     }
 
     @Test(expected = PageActionException.class)
@@ -386,7 +387,7 @@ public class PageService_CreateTest {
         conf.put(PageConfigurationKeys.TRANSLATION_LANG, "fr");
         newTranslation.setConfiguration(conf);
 
-        pageService.createPage(newTranslation);
+        pageService.createPage(newTranslation, GraviteeContext.getCurrentEnvironment());
     }
 
     @Test(expected = PageActionException.class)
@@ -402,7 +403,7 @@ public class PageService_CreateTest {
         conf.put(PageConfigurationKeys.TRANSLATION_LANG, "fr");
         newTranslation.setConfiguration(conf);
 
-        pageService.createPage(newTranslation);
+        pageService.createPage(newTranslation, GraviteeContext.getCurrentEnvironment());
     }
 
     @Test(expected = PageActionException.class)
@@ -419,7 +420,7 @@ public class PageService_CreateTest {
         conf.put(PageConfigurationKeys.TRANSLATION_LANG, "fr");
         newTranslation.setConfiguration(conf);
 
-        pageService.createPage(newTranslation);
+        pageService.createPage(newTranslation, GraviteeContext.getCurrentEnvironment());
     }
 
     @Test
@@ -447,7 +448,7 @@ public class PageService_CreateTest {
         createdPage.setVisibility("PUBLIC");
         doReturn(createdPage).when(pageRepository).create(any());
 
-        pageService.createPage(newTranslation);
+        pageService.createPage(newTranslation, GraviteeContext.getCurrentEnvironment());
         verify(pageRepository).create(argThat(p -> p.isPublished() == true));
         // create revision for translate if the parent page is a Markdown or Swagger
         verify(pageRevisionService, times(1)).create(any());
@@ -468,7 +469,7 @@ public class PageService_CreateTest {
         when(importConfiguration.isAllowImportFromPrivate()).thenReturn(false);
         when(importConfiguration.getImportWhitelist()).thenReturn(Collections.emptyList());
 
-        pageService.createPage(API_ID, newPage);
+        pageService.createPage(API_ID, newPage, GraviteeContext.getCurrentEnvironment());
 
         verify(pageRepository, never()).create(any());
     }
@@ -489,7 +490,7 @@ public class PageService_CreateTest {
         when(newPage.getVisibility()).thenReturn(Visibility.PUBLIC);
         when(this.notificationTemplateService.resolveInlineTemplateWithParam(anyString(), eq(content), any(), anyBoolean()))
             .thenReturn(content);
-        this.pageService.createPage(API_ID, newPage);
+        this.pageService.createPage(API_ID, newPage, GraviteeContext.getCurrentEnvironment());
 
         verify(pageRepository, never()).create(any());
     }
@@ -522,7 +523,7 @@ public class PageService_CreateTest {
 
         when(this.notificationTemplateService.resolveInlineTemplateWithParam(anyString(), eq(content), any(), anyBoolean()))
             .thenThrow(new TemplateProcessingException(new TemplateException(null)));
-        this.pageService.createPage(API_ID, newPage);
+        this.pageService.createPage(API_ID, newPage, GraviteeContext.getCurrentEnvironment());
 
         verify(pageRepository).create(any());
     }

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_DeleteTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_DeleteTest.java
@@ -28,9 +28,9 @@ import io.gravitee.rest.api.idp.api.authentication.UserDetails;
 import io.gravitee.rest.api.model.CategoryEntity;
 import io.gravitee.rest.api.model.PageConfigurationKeys;
 import io.gravitee.rest.api.model.PageType;
-import io.gravitee.rest.api.model.PageType;
 import io.gravitee.rest.api.model.PlanEntity;
 import io.gravitee.rest.api.model.PlanStatus;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.PageActionException;
 import io.gravitee.rest.api.service.exceptions.PageUsedAsGeneralConditionsException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -316,7 +316,7 @@ public class PageService_DeleteTest {
         when(pageRepository.search(new PageCriteria.Builder().referenceType(PageReferenceType.API.name()).referenceId("apiId").build()))
             .thenReturn(Arrays.asList(folder, child, childPage, page));
 
-        pageService.deleteAllByApi("apiId");
+        pageService.deleteAllByApi("apiId", GraviteeContext.getCurrentEnvironment());
 
         verify(pageRepository, times(6)).delete(idCaptor.capture());
         assertEquals(

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDescriptorTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDescriptorTest.java
@@ -32,6 +32,7 @@ import io.gravitee.rest.api.model.ImportPageEntity;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PageSourceEntity;
 import io.gravitee.rest.api.model.Visibility;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.RandomString;
 import io.gravitee.rest.api.service.impl.GraviteeDescriptorServiceImpl;
 import io.gravitee.rest.api.service.impl.PageServiceImpl;
@@ -127,7 +128,7 @@ public class PageService_ImportDescriptorTest {
         when(graviteeDescriptorService.descriptorName()).thenReturn(".gravitee.json");
         when(graviteeDescriptorService.read(anyString())).thenCallRealMethod();
 
-        List<PageEntity> pageEntities = pageService.importFiles(pageEntity);
+        List<PageEntity> pageEntities = pageService.importFiles(pageEntity, GraviteeContext.getCurrentEnvironment());
 
         assertNotNull(pageEntities);
         assertEquals(8, pageEntities.size());

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDirectoryTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDirectoryTest.java
@@ -32,6 +32,7 @@ import io.gravitee.rest.api.model.ImportPageEntity;
 import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PageSourceEntity;
 import io.gravitee.rest.api.model.Visibility;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.RandomString;
 import io.gravitee.rest.api.service.impl.PageServiceImpl;
 import io.gravitee.rest.api.service.search.SearchEngineService;
@@ -124,7 +125,7 @@ public class PageService_ImportDirectoryTest {
         when(pageRepository.create(any())).thenReturn(newPage);
         when(graviteeDescriptorService.descriptorName()).thenReturn(".gravitee.json");
 
-        List<PageEntity> pageEntities = pageService.importFiles(pageEntity);
+        List<PageEntity> pageEntities = pageService.importFiles(pageEntity, GraviteeContext.getCurrentEnvironment());
 
         assertNotNull(pageEntities);
         assertEquals(8, pageEntities.size());

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/promotion/PromotionServiceTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/promotion/PromotionServiceTest.java
@@ -37,6 +37,7 @@ import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.cockpit.services.CockpitReply;
 import io.gravitee.rest.api.service.cockpit.services.CockpitReplyStatus;
 import io.gravitee.rest.api.service.cockpit.services.CockpitService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.promotion.PromotionServiceImpl;
 import java.util.Arrays;
@@ -206,7 +207,7 @@ public class PromotionServiceTest {
         Page<Promotion> promotionPage = new Page<>(emptyList(), 0, 1, 1);
         when(promotionRepository.search(any(), any(), any())).thenReturn(promotionPage);
 
-        when(apiDuplicatorService.createWithImportedDefinition(any(), any())).thenReturn(new ApiEntity());
+        when(apiDuplicatorService.createWithImportedDefinition(any(), any(), any(), any())).thenReturn(new ApiEntity());
 
         CockpitReply<PromotionEntity> cockpitReply = new CockpitReply<>(null, CockpitReplyStatus.SUCCEEDED);
         when(cockpitService.processPromotion(any())).thenReturn(cockpitReply);
@@ -215,7 +216,7 @@ public class PromotionServiceTest {
 
         promotionService.processPromotion(PROMOTION_ID, true, USER_ID);
 
-        verify(apiDuplicatorService, times(1)).createWithImportedDefinition(any(), eq(USER_ID));
+        verify(apiDuplicatorService, times(1)).createWithImportedDefinition(any(), eq(USER_ID), any(), any());
         verify(promotionRepository, times(1)).update(any());
     }
 
@@ -228,7 +229,7 @@ public class PromotionServiceTest {
         Page<Promotion> promotionPage = new Page<>(singletonList(getAPromotion()), 0, 1, 1);
         when(promotionRepository.search(any(), any(), any())).thenReturn(promotionPage);
 
-        when(apiDuplicatorService.updateWithImportedDefinition(any(), any(), any())).thenReturn(new ApiEntity());
+        when(apiDuplicatorService.updateWithImportedDefinition(any(), any(), any(), any(), any())).thenReturn(new ApiEntity());
         when(apiService.exists(any())).thenReturn(true);
 
         ApiEntity existingApi = new ApiEntity();
@@ -242,7 +243,7 @@ public class PromotionServiceTest {
 
         promotionService.processPromotion(PROMOTION_ID, true, USER_ID);
 
-        verify(apiDuplicatorService, times(1)).updateWithImportedDefinition(any(), any(), eq(USER_ID));
+        verify(apiDuplicatorService, times(1)).updateWithImportedDefinition(any(), any(), eq(USER_ID), any(), any());
         verify(promotionRepository, times(1)).update(any());
     }
 
@@ -262,8 +263,8 @@ public class PromotionServiceTest {
 
         promotionService.processPromotion(PROMOTION_ID, false, USER_ID);
 
-        verify(apiDuplicatorService, never()).createWithImportedDefinition(any(), eq(USER_ID));
-        verify(apiDuplicatorService, never()).updateWithImportedDefinition(any(), any(), eq(USER_ID));
+        verify(apiDuplicatorService, never()).createWithImportedDefinition(any(), eq(USER_ID), any(), any());
+        verify(apiDuplicatorService, never()).updateWithImportedDefinition(any(), any(), eq(USER_ID), any(), any());
         verify(promotionRepository, times(1)).update(any());
     }
 
@@ -293,7 +294,7 @@ public class PromotionServiceTest {
         when(promotionRepository.search(any(), any(), any())).thenReturn(promotionPage);
 
         when(apiService.exists(any())).thenReturn(true);
-        when(apiDuplicatorService.updateWithImportedDefinition(any(), any(), any())).thenReturn(new ApiEntity());
+        when(apiDuplicatorService.updateWithImportedDefinition(any(), any(), any(), any(), any())).thenReturn(new ApiEntity());
 
         ApiEntity existingApi = new ApiEntity();
         existingApi.setId("api#existing");
@@ -304,7 +305,7 @@ public class PromotionServiceTest {
 
         promotionService.processPromotion(PROMOTION_ID, true, USER_ID);
 
-        verify(apiDuplicatorService, times(1)).updateWithImportedDefinition(any(), any(), eq(USER_ID));
+        verify(apiDuplicatorService, times(1)).updateWithImportedDefinition(any(), any(), eq(USER_ID), any(), any());
         verify(promotionRepository, times(0)).update(any());
     }
 

--- a/gravitee-rest-api-services/gravitee-rest-api-services-auto-fetch/src/main/java/io/gravitee/rest/api/services/fetcher/ScheduledAutoFetchService.java
+++ b/gravitee-rest-api-services/gravitee-rest-api-services-auto-fetch/src/main/java/io/gravitee/rest/api/services/fetcher/ScheduledAutoFetchService.java
@@ -17,6 +17,7 @@ package io.gravitee.rest.api.services.fetcher;
 
 import io.gravitee.common.service.AbstractService;
 import io.gravitee.rest.api.service.PageService;
+import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.services.fetcher.spring.AutoFetchConfiguration;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicLong;
@@ -64,7 +65,7 @@ public class ScheduledAutoFetchService extends AbstractService implements Runnab
     @Override
     public void run() {
         LOGGER.debug("Auto Fetch #{} started at {}", counter.incrementAndGet(), Instant.now());
-        pageService.execAutoFetch();
+        pageService.execAutoFetch(GraviteeContext.getCurrentEnvironment());
         LOGGER.debug("Auto Fetch #{} ended at {}", counter.get(), Instant.now());
     }
 }


### PR DESCRIPTION
**Issue**

NA

**Description**

Extract calls to `GraviteeContext.getCurrentEnvironment` and `GraviteeContext.getCurrentOrganization` from PageService methods by passing this info as parameters. This will enable us to create pages by specifying the env instead of relying on the scope one. It would be especially useful when it is not defined (like during API promotion process).
