### PR TITLE
Small fix and enhancement on API Promotion

### DIFF
--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -422,8 +422,8 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
 
             // Add Default groups
             Set<String> defaultGroups = groupService.findByEvent(GroupEvent.API_CREATE).stream().map(GroupEntity::getId).collect(toSet());
-            if (!defaultGroups.isEmpty() && repoApi.getGroups() == null) {
-                repoApi.setGroups(defaultGroups);
+            if (repoApi.getGroups() == null) {
+                repoApi.setGroups(defaultGroups.isEmpty() ? null : defaultGroups);
             } else {
                 repoApi.getGroups().addAll(defaultGroups);
             }


### PR DESCRIPTION
**Issue**

NA

**Description**

 - put back checks on default group when creating an API, partially revert 540dbfc
 - set promotion status to ERROR when the sending to cockpit fails

