### PR TITLE
fix: check API roles for API pages access control

### DIFF
--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResource.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResource.java
@@ -66,7 +66,7 @@ public class ApiPageResource extends AbstractResource {
 
             PageEntity pageEntity = pageService.findById(pageId, acceptedLocale);
 
-            if (accessControlService.canAccessPageFromPortal(pageEntity)) {
+            if (accessControlService.canAccessPageFromPortal(apiId, pageEntity)) {
                 pageService.transformSwagger(pageEntity, apiId);
 
                 if (!isAuthenticated() && pageEntity.getMetadata() != null) {
@@ -102,7 +102,7 @@ public class ApiPageResource extends AbstractResource {
         apiQuery.setIds(Collections.singletonList(apiId));
         if (accessControlService.canAccessApiFromPortal(apiId)) {
             PageEntity pageEntity = pageService.findById(pageId, null);
-            if (accessControlService.canAccessPageFromPortal(pageEntity)) {
+            if (accessControlService.canAccessPageFromPortal(apiId, pageEntity)) {
                 pageService.transformSwagger(pageEntity, apiId);
                 return Response.ok(pageEntity.getContent()).build();
             } else {

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResource.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/main/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResource.java
@@ -80,7 +80,7 @@ public class ApiPagesResource extends AbstractResource {
                     GraviteeContext.getCurrentEnvironment()
                 )
                 .stream()
-                .filter(accessControlService::canAccessPageFromPortal)
+                .filter(page -> accessControlService.canAccessPageFromPortal(apiId, page))
                 .map(pageMapper::convert)
                 .map(page -> this.addPageLink(apiId, page));
 

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResourceNotAuthenticatedTest.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResourceNotAuthenticatedTest.java
@@ -121,7 +121,7 @@ public class ApiPageResourceNotAuthenticatedTest extends AbstractResourceTest {
     @Test
     public void shouldHaveMetadataCleared() {
         doReturn(true).when(accessControlService).canAccessApiFromPortal(API);
-        doReturn(true).when(accessControlService).canAccessPageFromPortal(any(PageEntity.class));
+        doReturn(true).when(accessControlService).canAccessPageFromPortal(eq(API), any(PageEntity.class));
 
         Response anotherResponse = target(API).path("pages").path(ANOTHER_PAGE).request().get();
         assertEquals(OK_200, anotherResponse.getStatus());

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResourceTest.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPageResourceTest.java
@@ -18,8 +18,7 @@ package io.gravitee.rest.api.portal.rest.resource;
 import static io.gravitee.common.http.HttpStatusCode.*;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 
@@ -70,7 +69,7 @@ public class ApiPageResourceTest extends AbstractResourceTest {
         page1.setVisibility(Visibility.PUBLIC);
         page1.setContent(PAGE_CONTENT);
         doReturn(page1).when(pageService).findById(PAGE, null);
-        doReturn(true).when(accessControlService).canAccessPageFromPortal(page1);
+        doReturn(true).when(accessControlService).canAccessPageFromPortal(API, page1);
 
         doReturn(new Page()).when(pageMapper).convert(any(), any(), any());
         doReturn(new PageLinks()).when(pageMapper).computePageLinks(any(), any());
@@ -140,7 +139,7 @@ public class ApiPageResourceTest extends AbstractResourceTest {
     @Test
     public void shouldNotGetApiPage() {
         final Builder request = target(API).path("pages").path(PAGE).request();
-        doReturn(false).when(accessControlService).canAccessPageFromPortal(any());
+        doReturn(false).when(accessControlService).canAccessPageFromPortal(eq(API), any());
 
         Response response = request.get();
         assertEquals(UNAUTHORIZED_401, response.getStatus());
@@ -216,7 +215,7 @@ public class ApiPageResourceTest extends AbstractResourceTest {
     @Test
     public void shouldNotGetApiPageContent() {
         final Builder request = target(API).path("pages").path(PAGE).path("content").request();
-        doReturn(false).when(accessControlService).canAccessPageFromPortal(any());
+        doReturn(false).when(accessControlService).canAccessPageFromPortal(eq(API), any());
 
         Response response = request.get();
         assertEquals(UNAUTHORIZED_401, response.getStatus());

--- a/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResourceTest.java
+++ b/gravitee-rest-api-portal/gravitee-rest-api-portal-rest/src/test/java/io/gravitee/rest/api/portal/rest/resource/ApiPagesResourceTest.java
@@ -63,10 +63,10 @@ public class ApiPagesResourceTest extends AbstractResourceTest {
             .when(pageService)
             .search(any(), isNull(), eq(GraviteeContext.getCurrentEnvironment()));
 
-        when(accessControlService.canAccessPageFromPortal(any(PageEntity.class)))
+        when(accessControlService.canAccessPageFromPortal(eq(API), any(PageEntity.class)))
             .thenAnswer(
                 invocationOnMock -> {
-                    PageEntity page = invocationOnMock.getArgument(0);
+                    PageEntity page = invocationOnMock.getArgument(1);
                     return !PageType.MARKDOWN_TEMPLATE.name().equals(page.getType());
                 }
             );
@@ -115,7 +115,7 @@ public class ApiPagesResourceTest extends AbstractResourceTest {
     @Test
     public void shouldGetNoApiPage() {
         when(accessControlService.canAccessApiFromPortal(API)).thenReturn(true);
-        when(accessControlService.canAccessPageFromPortal(any())).thenReturn(false);
+        when(accessControlService.canAccessPageFromPortal(eq(API), any())).thenReturn(false);
 
         final Builder request = target(API).path("pages").request();
 

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/AccessControlService.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/AccessControlService.java
@@ -29,6 +29,8 @@ public interface AccessControlService {
 
     boolean canAccessPageFromPortal(PageEntity pageEntity);
 
+    boolean canAccessPageFromPortal(String apiId, PageEntity pageEntity);
+
     boolean canAccessPageFromConsole(PageEntity pageEntity);
 
     boolean canAccessPageFromConsole(ApiEntity apiEntity, PageEntity pageEntity);

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AccessControlServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AccessControlServiceImpl.java
@@ -119,8 +119,17 @@ public class AccessControlServiceImpl extends AbstractService implements AccessC
 
     @Override
     public boolean canAccessPageFromPortal(PageEntity pageEntity) {
+        return canAccessPageFromPortal(null, pageEntity);
+    }
+
+    @Override
+    public boolean canAccessPageFromPortal(String apiId, PageEntity pageEntity) {
         if (PageType.SYSTEM_FOLDER.name().equals(pageEntity.getType()) || PageType.MARKDOWN_TEMPLATE.name().equals(pageEntity.getType())) {
             return false;
+        }
+        if (apiId != null) {
+            final ApiEntity apiEntity = apiService.findById(apiId);
+            return canAccessPage(apiEntity, pageEntity);
         }
         return canAccessPage(null, pageEntity);
     }

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/AccessControlServiceTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/AccessControlServiceTest.java
@@ -51,6 +51,7 @@ public class AccessControlServiceTest {
     public static final String USERNAME = "johndoe";
     private static final String ROLE_ID = "my-role";
     private static final String GROUP_ID = "my-group";
+    private static final String API_ID = "my-api";
 
     @InjectMocks
     private AccessControlService accessControlService = new AccessControlServiceImpl();
@@ -372,6 +373,31 @@ public class AccessControlServiceTest {
         when(membershipServiceMock.getUserMember(MembershipReferenceType.GROUP, GROUP_ID, USERNAME)).thenReturn(memberEntity);
 
         boolean canAccess = accessControlService.canAccessPageFromConsole(apiEntityMock, pageEntity);
+
+        assertTrue(canAccess);
+    }
+
+    @Test
+    public void shouldAccessApiPageFromPortalWithRole() {
+        final ApiEntity apiEntityMock = new ApiEntity();
+        apiEntityMock.setId(API_ID);
+
+        when(apiService.findById(API_ID)).thenReturn(apiEntityMock);
+
+        final PageEntity pageEntity = mock(PageEntity.class);
+        when(pageEntity.isPublished()).thenReturn(true);
+        when(pageEntity.getVisibility()).thenReturn(Visibility.PRIVATE);
+        Set<AccessControlEntity> accessControls = buildAccessControls(Arrays.asList(ROLE_ID));
+        when(pageEntity.getAccessControls()).thenReturn(accessControls);
+        connectUser();
+
+        Set<RoleEntity> roles = new HashSet<>();
+        RoleEntity roleEntity = new RoleEntity();
+        roleEntity.setId(ROLE_ID);
+        roles.add(roleEntity);
+        when(membershipServiceMock.getRoles(MembershipReferenceType.API, API_ID, MembershipMemberType.USER, USERNAME)).thenReturn(roles);
+
+        boolean canAccess = accessControlService.canAccessPageFromPortal(API_ID, pageEntity);
 
         assertTrue(canAccess);
     }


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5789

**Description**

Use API roles instead of environment roles to check the access of API pages (if access control is defined on this API)