### PR TITLE
fix(documentation): set imported pages visible by default

### DIFF
--- a/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/ImportPageEntity.java
+++ b/gravitee-rest-api-model/src/main/java/io/gravitee/rest/api/model/ImportPageEntity.java
@@ -32,8 +32,7 @@ public class ImportPageEntity {
 
     private boolean published;
 
-    @NotNull
-    private Visibility visibility;
+    private Visibility visibility = Visibility.PUBLIC;
 
     private String lastContributor;
     private PageSourceEntity source;

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDescriptorTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDescriptorTest.java
@@ -102,7 +102,6 @@ public class PageService_ImportDescriptorTest {
         pageSource.setConfiguration(mapper.readTree("{}"));
         ImportPageEntity pageEntity = new ImportPageEntity();
         pageEntity.setSource(pageSource);
-        pageEntity.setVisibility(Visibility.PUBLIC);
         FetcherPlugin fetcherPlugin = mock(FetcherPlugin.class);
         when(fetcherPlugin.clazz()).thenReturn("io.gravitee.rest.api.service.PageService_ImportDescriptorMockFetcher");
         when(fetcherPlugin.configuration()).thenReturn(PageService_MockDescriptorFetcherConfiguration.class);

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDirectoryTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDirectoryTest.java
@@ -99,7 +99,6 @@ public class PageService_ImportDirectoryTest {
         ImportPageEntity pageEntity = new ImportPageEntity();
         pageEntity.setSource(pageSource);
         pageEntity.setPublished(true);
-        pageEntity.setVisibility(Visibility.PUBLIC);
         FetcherPlugin fetcherPlugin = mock(FetcherPlugin.class);
         when(fetcherPlugin.clazz()).thenReturn("io.gravitee.rest.api.service.PageService_ImportDirectoryMockFetcher");
         when(fetcherPlugin.configuration()).thenReturn(PageService_MockFilesFetcherConfiguration.class);


### PR DESCRIPTION
**Issue**

gravitee-io/issues#5932

**Description**

Remove the @NotNull annotation on the `Visibility` field of the `ImportPageEntity` class. Set visibility to PUBLIC by default.

