### PR TITLE
Bump `gravitee-plugin` & `gravitee-cockpit-api`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <gravitee-api-management.version>3.10.0-SNAPSHOT</gravitee-api-management.version>
         <gravitee-common.version>1.20.1</gravitee-common.version>
         <gravitee-definition.version>1.28.0</gravitee-definition.version>
-        <gravitee-plugin.version>1.18.0-SNAPSHOT</gravitee-plugin.version>
+        <gravitee-plugin.version>1.18.0</gravitee-plugin.version>
         <gravitee-gateway-api.version>1.26.0</gravitee-gateway-api.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-expression-language.version>1.6.0-SNAPSHOT</gravitee-expression-language.version>
@@ -47,7 +47,7 @@
         <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <gravitee-resource-cache-provider-api.version>1.1.0-SNAPSHOT</gravitee-resource-cache-provider-api.version>
-        <gravitee-cockpit-api.version>1.7.0-SNAPSHOT</gravitee-cockpit-api.version>
+        <gravitee-cockpit-api.version>1.7.0</gravitee-cockpit-api.version>
         <apacheds-server-jndi.version>1.5.5</apacheds-server-jndi.version>
         <commons-io.version>2.7</commons-io.version>
         <javax.servlet-api.version>3.1.0</javax.servlet-api.version>


### PR DESCRIPTION
**Issue**

NA

**Description**

gravitee-cockpit-connectors@2.0.0 needs gravitee-cockpit-api@1.7.0 & gravitee-plugin@1.18.0
