### PR TITLE
chore(alert): bump alert-api to 1.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,9 @@
         <gravitee-gateway-api.version>1.20.1</gravitee-gateway-api.version>
         <gravitee-fetcher-api.version>1.4.0</gravitee-fetcher-api.version>
         <gravitee-expression-language.version>1.5.0</gravitee-expression-language.version>
-        <gravitee-alert-api.version>1.6.0</gravitee-alert-api.version>
+        <gravitee-alert-api.version>1.7.1</gravitee-alert-api.version>
         <gravitee-policy-api.version>1.10.0</gravitee-policy-api.version>
-        <gravitee-notifier-api.version>1.2.1</gravitee-notifier-api.version>
+        <gravitee-notifier-api.version>1.4.1</gravitee-notifier-api.version>
         <gravitee-api-management.version>3.5.18-SNAPSHOT</gravitee-api-management.version>
         <gravitee-resource-oauth2-provider-api.version>1.3.0</gravitee-resource-oauth2-provider-api.version>
         <apacheds-server-jndi.version>1.5.5</apacheds-server-jndi.version>


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5890

**Description**

Upgrade alert-api