### PR TITLE
Fix API Creation with multiple pages

### DIFF
--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/UuidString.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/common/UuidString.java
@@ -16,19 +16,29 @@
 package io.gravitee.rest.api.service.common;
 
 import io.gravitee.common.utils.UUID;
+import java.util.Objects;
+import java.util.stream.Stream;
 
 /**
- * Random version-4 UUID will have 6 predetermined variant and version bits, leaving 122 bits for the randomly generated part.
+ * UuidString class generates UUID strings. Randomly, or from fields.
  *
  * @author Titouan COMPIEGNE (titouan.compiegne at graviteesource.com)
  * @author GraviteeSource Team
  */
-public interface RandomString {
-    static String generate() {
+public interface UuidString {
+    /**
+     * Random version-4 UUID will have 6 predetermined variant and version bits, leaving 122 bits for the randomly generated part.
+     * @return A random UUID as string
+     */
+    static String generateRandom() {
         return UUID.toString(UUID.random());
     }
 
     static String generateForEnvironment(String environmentId, String... fields) {
+        if (Stream.of(fields).anyMatch(Objects::isNull)) {
+            return generateRandom();
+        }
+
         StringBuilder b = new StringBuilder();
         b.append(environmentId);
         for (String f : fields) {

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiDuplicatorServiceImpl.java
@@ -17,7 +17,6 @@ package io.gravitee.rest.api.service.impl;
 
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -34,10 +33,8 @@ import io.gravitee.rest.api.model.api.DuplicateApiEntity;
 import io.gravitee.rest.api.model.api.UpdateApiEntity;
 import io.gravitee.rest.api.model.documentation.PageQuery;
 import io.gravitee.rest.api.model.permissions.RoleScope;
-import io.gravitee.rest.api.model.plan.PlanQuery;
 import io.gravitee.rest.api.service.*;
-import io.gravitee.rest.api.service.common.RandomString;
-import io.gravitee.rest.api.service.exceptions.PlanNotFoundException;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import io.gravitee.rest.api.service.jackson.ser.api.ApiSerializer;
@@ -516,7 +513,7 @@ public class ApiDuplicatorServiceImpl extends AbstractService implements ApiDupl
                 planEntity -> {
                     planEntity.setApi(createdOrUpdatedApiEntity.getId());
                     planEntity.setId(
-                        RandomString.generateForEnvironment(environmentId, createdOrUpdatedApiEntity.getId(), planEntity.getId())
+                        UuidString.generateForEnvironment(environmentId, createdOrUpdatedApiEntity.getId(), planEntity.getId())
                     );
                     planService.createOrUpdatePlan(planEntity, environmentId);
                 }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiHeaderServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiHeaderServiceImpl.java
@@ -29,7 +29,7 @@ import io.gravitee.rest.api.model.api.header.UpdateApiHeaderEntity;
 import io.gravitee.rest.api.service.ApiHeaderService;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.ApiHeaderNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.*;
@@ -63,7 +63,7 @@ public class ApiHeaderServiceImpl extends TransactionalService implements ApiHea
             int order = apiHeaderRepository.findAllByEnvironment(environmentId).size() + 1;
 
             ApiHeader apiHeader = new ApiHeader();
-            apiHeader.setId(RandomString.generate());
+            apiHeader.setId(UuidString.generateRandom());
             apiHeader.setEnvironmentId(environmentId);
             apiHeader.setName(newEntity.getName());
             apiHeader.setValue(newEntity.getValue());

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApiServiceImpl.java
@@ -82,7 +82,7 @@ import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.search.SearchResult;
 import io.gravitee.rest.api.service.impl.upgrade.DefaultMetadataUpgrader;
@@ -373,7 +373,7 @@ public class ApiServiceImpl extends AbstractService implements ApiService {
             LOGGER.debug("Create {} for user {}", api, userId);
 
             String apiId = apiDefinition != null && apiDefinition.has("id") ? apiDefinition.get("id").asText() : null;
-            String id = apiId != null && UUID.fromString(apiId) != null ? apiId : RandomString.generate();
+            String id = apiId != null && UUID.fromString(apiId) != null ? apiId : UuidString.generateRandom();
 
             Optional<Api> checkApi = apiRepository.findById(id);
             if (checkApi.isPresent()) {

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/ApplicationServiceImpl.java
@@ -46,7 +46,7 @@ import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.configuration.application.ApplicationTypeService;
 import io.gravitee.rest.api.service.configuration.application.ClientRegistrationService;
 import io.gravitee.rest.api.service.exceptions.*;
@@ -430,7 +430,7 @@ public class ApplicationServiceImpl extends AbstractService implements Applicati
         }
 
         Application application = convert(newApplicationEntity);
-        application.setId(RandomString.generate());
+        application.setId(UuidString.generateRandom());
         application.setStatus(ApplicationStatus.ACTIVE);
         metadata.forEach((key, value) -> application.getMetadata().put(key, value));
 

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/AuditServiceImpl.java
@@ -34,7 +34,7 @@ import io.gravitee.rest.api.model.audit.AuditQuery;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
 import java.util.*;
@@ -308,7 +308,7 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
         Object newValue
     ) {
         Audit audit = new Audit();
-        audit.setId(RandomString.generate());
+        audit.setId(UuidString.generateRandom());
         audit.setCreatedAt(createdAt == null ? new Date() : createdAt);
 
         final UserDetails authenticatedUser = getAuthenticatedUser();

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CategoryServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CategoryServiceImpl.java
@@ -32,7 +32,7 @@ import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.CategoryService;
 import io.gravitee.rest.api.service.EnvironmentService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.CategoryNotFoundException;
 import io.gravitee.rest.api.service.exceptions.DuplicateCategoryNameException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -296,7 +296,7 @@ public class CategoryServiceImpl extends TransactionalService implements Categor
 
     private Category convert(final NewCategoryEntity categoryEntity) {
         final Category category = new Category();
-        category.setId(RandomString.generate());
+        category.setId(UuidString.generateRandom());
         category.setKey(IdGenerator.generate(categoryEntity.getName()));
         category.setName(categoryEntity.getName());
         category.setDescription(categoryEntity.getDescription());

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CommandServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/CommandServiceImpl.java
@@ -26,7 +26,7 @@ import io.gravitee.rest.api.model.command.CommandTags;
 import io.gravitee.rest.api.model.command.NewCommandEntity;
 import io.gravitee.rest.api.service.CommandService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.Message2RecipientNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.Collections;
@@ -61,7 +61,7 @@ public class CommandServiceImpl extends AbstractService implements CommandServic
         }
 
         Command command = new Command();
-        command.setId(RandomString.generate());
+        command.setId(UuidString.generateRandom());
         command.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
         command.setFrom(node.id());
         command.setTo(messageEntity.getTo());

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/DashboardServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/DashboardServiceImpl.java
@@ -24,7 +24,6 @@ import static java.util.stream.Collectors.toList;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.gravitee.common.utils.UUID;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.DashboardRepository;
 import io.gravitee.repository.management.model.Dashboard;
@@ -34,7 +33,7 @@ import io.gravitee.rest.api.model.NewDashboardEntity;
 import io.gravitee.rest.api.model.UpdateDashboardEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.DashboardService;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.DashboardNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.io.File;
@@ -251,7 +250,7 @@ public class DashboardServiceImpl extends AbstractService implements DashboardSe
 
     private Dashboard convert(final NewDashboardEntity dashboardEntity, final List<Dashboard> dashboards) {
         final Dashboard dashboard = new Dashboard();
-        dashboard.setId(RandomString.generate());
+        dashboard.setId(UuidString.generateRandom());
         dashboard.setReferenceId(dashboardEntity.getReferenceId());
         dashboard.setReferenceType(dashboardEntity.getReferenceType().name());
         dashboard.setName(dashboardEntity.getName());

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EntrypointServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EntrypointServiceImpl.java
@@ -28,7 +28,7 @@ import io.gravitee.rest.api.model.NewEntryPointEntity;
 import io.gravitee.rest.api.model.UpdateEntryPointEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.EntrypointService;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.EntrypointNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.*;
@@ -170,7 +170,7 @@ public class EntrypointServiceImpl extends TransactionalService implements Entry
 
     private Entrypoint convert(final NewEntryPointEntity entrypointEntity, String referenceId, EntrypointReferenceType referenceType) {
         final Entrypoint entrypoint = new Entrypoint();
-        entrypoint.setId(RandomString.generate());
+        entrypoint.setId(UuidString.generateRandom());
         entrypoint.setValue(entrypointEntity.getValue());
         entrypoint.setTags(String.join(SEPARATOR, entrypointEntity.getTags()));
         entrypoint.setReferenceId(referenceId);

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EventServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/EventServiceImpl.java
@@ -30,7 +30,7 @@ import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.service.EventService;
 import io.gravitee.rest.api.service.UserService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.EventNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.exceptions.UserNotFoundException;
@@ -85,7 +85,7 @@ public class EventServiceImpl extends TransactionalService implements EventServi
             LOGGER.debug("Create {} for server {}", newEventEntity, hostAddress);
 
             Event event = convert(newEventEntity);
-            event.setId(RandomString.generate());
+            event.setId(UuidString.generateRandom());
             event.setEnvironments(Collections.singleton(GraviteeContext.getCurrentEnvironment()));
             // Set origin
             event.getProperties().put(Event.EventProperties.ORIGIN.getValue(), hostAddress);

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GenericNotificationConfigServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GenericNotificationConfigServiceImpl.java
@@ -23,7 +23,7 @@ import io.gravitee.repository.management.model.User;
 import io.gravitee.rest.api.model.notification.GenericNotificationConfigEntity;
 import io.gravitee.rest.api.model.notification.NotificationConfigType;
 import io.gravitee.rest.api.service.GenericNotificationConfigService;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.BadNotificationConfigException;
 import io.gravitee.rest.api.service.exceptions.NotificationConfigNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -53,7 +53,7 @@ public class GenericNotificationConfigServiceImpl extends AbstractService implem
         }
         try {
             GenericNotificationConfig notificationConfig = convert(entity);
-            notificationConfig.setId(RandomString.generate());
+            notificationConfig.setId(UuidString.generateRandom());
             notificationConfig.setCreatedAt(new Date());
             notificationConfig.setUpdatedAt(notificationConfig.getCreatedAt());
             return convert(genericNotificationConfigRepository.create(notificationConfig));

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/GroupServiceImpl.java
@@ -40,7 +40,7 @@ import io.gravitee.rest.api.model.permissions.SystemRole;
 import io.gravitee.rest.api.model.settings.ApiPrimaryOwnerMode;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.*;
 import java.util.*;
 import java.util.function.Consumer;
@@ -213,7 +213,7 @@ public class GroupServiceImpl extends AbstractService implements GroupService {
                 throw new GroupNameAlreadyExistsException(group.getName());
             }
             Group newGroup = this.map(group);
-            newGroup.setId(RandomString.generate());
+            newGroup.setId(UuidString.generateRandom());
             newGroup.setEnvironmentId(GraviteeContext.getCurrentEnvironment());
             newGroup.setCreatedAt(new Date());
             newGroup.setUpdatedAt(newGroup.getCreatedAt());

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/HttpClientServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/HttpClientServiceImpl.java
@@ -20,7 +20,7 @@ import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
 import io.gravitee.rest.api.service.HttpClientService;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
@@ -142,7 +142,7 @@ public class HttpClientServiceImpl extends AbstractService implements HttpClient
             headers.forEach(options::putHeader);
         }
 
-        options.putHeader("X-Gravitee-Request-Id", RandomString.generate().trim());
+        options.putHeader("X-Gravitee-Request-Id", UuidString.generateRandom().trim());
 
         if (body != null) {
             if (!options.getHeaders().contains(HttpHeaders.CONTENT_TYPE)) {

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstallationServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InstallationServiceImpl.java
@@ -20,7 +20,7 @@ import io.gravitee.repository.management.model.Installation;
 import io.gravitee.rest.api.model.InstallationEntity;
 import io.gravitee.rest.api.model.InstallationStatus;
 import io.gravitee.rest.api.service.InstallationService;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.InstallationNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.time.Instant;
@@ -102,7 +102,7 @@ public class InstallationServiceImpl implements InstallationService {
     private InstallationEntity createInstallation() {
         final Date now = Date.from(Instant.now());
         final Installation installation = new Installation();
-        installation.setId(RandomString.generate());
+        installation.setId(UuidString.generateRandom());
         installation.setCreatedAt(now);
         installation.setUpdatedAt(now);
         installation.setAdditionalInformation(new HashMap<>());

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InvitationServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/InvitationServiceImpl.java
@@ -21,19 +21,17 @@ import static io.gravitee.rest.api.service.notification.NotificationParamsBuilde
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 
-import io.gravitee.common.data.domain.Page;
 import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.InvitationRepository;
 import io.gravitee.repository.management.model.Invitation;
 import io.gravitee.rest.api.model.*;
-import io.gravitee.rest.api.model.common.PageableImpl;
 import io.gravitee.rest.api.model.permissions.RolePermission;
 import io.gravitee.rest.api.model.permissions.RoleScope;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.MembershipService.MembershipReference;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.InvitationEmailAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.InvitationNotFoundException;
 import io.gravitee.rest.api.service.exceptions.MemberEmailAlreadyExistsException;
@@ -252,7 +250,7 @@ public class InvitationServiceImpl extends TransactionalService implements Invit
 
     private Invitation convert(final NewInvitationEntity invitationEntity) {
         final Invitation invitation = new Invitation();
-        invitation.setId(RandomString.generate());
+        invitation.setId(UuidString.generateRandom());
         invitation.setReferenceId(invitationEntity.getReferenceId());
         invitation.setReferenceType(invitationEntity.getReferenceType().name());
         invitation.setApiRole(invitationEntity.getApiRole());

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MediaServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MediaServiceImpl.java
@@ -25,7 +25,7 @@ import io.gravitee.rest.api.model.MediaEntity;
 import io.gravitee.rest.api.model.PageMediaEntity;
 import io.gravitee.rest.api.service.ConfigService;
 import io.gravitee.rest.api.service.MediaService;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -70,7 +70,7 @@ public class MediaServiceImpl implements MediaService {
             String hashString = DatatypeConverter.printHexBinary(hash);
             String id = mediaEntity.getId() != null && UUID.fromString(mediaEntity.getId()) != null
                 ? mediaEntity.getId()
-                : RandomString.generate();
+                : UuidString.generateRandom();
 
             Optional<Media> checkMedia = null;
 

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/MembershipServiceImpl.java
@@ -47,7 +47,7 @@ import io.gravitee.rest.api.model.providers.User;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.notification.NotificationParamsBuilder;
 import java.util.*;
@@ -195,7 +195,7 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 if (member.getMemberType() == MembershipMemberType.USER) {
                     UserEntity userEntity = findUserFromMembershipMember(member);
                     io.gravitee.repository.management.model.Membership membership = new io.gravitee.repository.management.model.Membership(
-                        RandomString.generate(),
+                        UuidString.generateRandom(),
                         userEntity.getId(),
                         convert(member.getMemberType()),
                         reference.getId(),
@@ -247,7 +247,7 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                     userMember = getUserMember(reference.getType(), reference.getId(), userEntity.getId());
                 } else {
                     io.gravitee.repository.management.model.Membership membership = new io.gravitee.repository.management.model.Membership(
-                        RandomString.generate(),
+                        UuidString.generateRandom(),
                         member.getMemberId(),
                         convert(member.getMemberType()),
                         reference.getId(),
@@ -1336,7 +1336,7 @@ public class MembershipServiceImpl extends AbstractService implements Membership
                 );
                 String oldMembershipId = membership.getId();
                 if (membershipsWithNewRole.isEmpty()) {
-                    membership.setId(RandomString.generate());
+                    membership.setId(UuidString.generateRandom());
                     membership.setRoleId(newRoleId);
                     membership.setSource(DEFAULT_SOURCE);
                     membershipRepository.create(membership);

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotificationTemplateServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/NotificationTemplateServiceImpl.java
@@ -37,7 +37,7 @@ import io.gravitee.rest.api.model.notification.NotificationTemplateEvent;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder.EmailTemplate;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.NotificationTemplateNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.exceptions.TemplateProcessingException;
@@ -384,7 +384,7 @@ public class NotificationTemplateServiceImpl extends AbstractService implements 
     public NotificationTemplateEntity create(NotificationTemplateEntity newNotificationTemplate) {
         try {
             LOGGER.debug("Create notificationTemplate {}", newNotificationTemplate);
-            newNotificationTemplate.setId(RandomString.generate());
+            newNotificationTemplate.setId(UuidString.generateRandom());
             if (newNotificationTemplate.getCreatedAt() == null) {
                 newNotificationTemplate.setCreatedAt(new Date());
             }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PageServiceImpl.java
@@ -45,7 +45,7 @@ import io.gravitee.rest.api.model.descriptor.GraviteeDescriptorEntity;
 import io.gravitee.rest.api.model.descriptor.GraviteeDescriptorPageEntity;
 import io.gravitee.rest.api.model.documentation.PageQuery;
 import io.gravitee.rest.api.service.*;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.swagger.parser.OAIParser;
 import io.gravitee.rest.api.service.impl.swagger.transformer.SwaggerTransformer;
@@ -712,7 +712,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
         try {
             logger.debug("Create page {} for API {}", newPageEntity, apiId);
 
-            String id = pageId != null && UUID.fromString(pageId) != null ? pageId : RandomString.generate();
+            String id = pageId != null && UUID.fromString(pageId) != null ? pageId : UuidString.generateRandom();
 
             PageType newPageType = newPageEntity.getType();
 
@@ -1845,7 +1845,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             if (searchResult.isEmpty()) {
                 page.setCreatedAt(new Date());
                 page.setUpdatedAt(page.getCreatedAt());
-                page.setId(RandomString.generate());
+                page.setId(UuidString.generateRandom());
                 validateSafeContent(page);
                 return pageRepository.create(page);
             } else {
@@ -2582,7 +2582,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             PageEntity pageEntityToImport = child.data;
             pageEntityToImport.setParentId(parentId);
 
-            String newPageEntityId = RandomString.generateForEnvironment(environmentId, apiId, pageEntityToImport.getId());
+            String newPageEntityId = UuidString.generateForEnvironment(environmentId, apiId, pageEntityToImport.getId());
 
             PageEntity createdOrUpdatedPage = null;
             if (pageEntityToImport.getId() != null) {
@@ -2634,7 +2634,7 @@ public class PageServiceImpl extends AbstractService implements PageService, App
             PageEntity pageEntityToImport = child.data;
             pageEntityToImport.setParentId(parentId);
 
-            String newId = RandomString.generateForEnvironment(environmentId, apiId, pageEntityToImport.getId());
+            String newId = UuidString.generateForEnvironment(environmentId, apiId, pageEntityToImport.getId());
             createPage(apiId, NewPageEntity.from(pageEntityToImport), environmentId, newId);
 
             if (child.children != null && !child.children.isEmpty()) {

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PlanServiceImpl.java
@@ -37,7 +37,7 @@ import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.plan.PlanQuery;
 import io.gravitee.rest.api.service.*;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.processor.PlanSynchronizationProcessor;
 import java.io.IOException;
@@ -161,7 +161,7 @@ public class PlanServiceImpl extends TransactionalService implements PlanService
                 throw new ApiDeprecatedException(api.getName());
             }
 
-            String id = newPlan.getId() != null && UUID.fromString(newPlan.getId()) != null ? newPlan.getId() : RandomString.generate();
+            String id = newPlan.getId() != null && UUID.fromString(newPlan.getId()) != null ? newPlan.getId() : UuidString.generateRandom();
 
             Plan plan = new Plan();
             plan.setId(id);
@@ -273,7 +273,7 @@ public class PlanServiceImpl extends TransactionalService implements PlanService
                 NewPlanEntity newPlan = NewPlanEntity.from(plan);
                 newPlan.setApi(apiId);
 
-                String newPlanId = RandomString.generateForEnvironment(environmentId, apiId, plan.getId());
+                String newPlanId = UuidString.generateForEnvironment(environmentId, apiId, plan.getId());
                 newPlan.setId(newPlanId);
                 create(newPlan);
             }

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PortalNotificationServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/PortalNotificationServiceImpl.java
@@ -21,7 +21,7 @@ import io.gravitee.repository.management.model.PortalNotification;
 import io.gravitee.rest.api.model.notification.NewPortalNotificationEntity;
 import io.gravitee.rest.api.model.notification.PortalNotificationEntity;
 import io.gravitee.rest.api.service.PortalNotificationService;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.PortalNotificationNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notification.Hook;
@@ -124,7 +124,7 @@ public class PortalNotificationServiceImpl extends AbstractService implements Po
         List<PortalNotification> notifications = notificationEntities.stream().map(this::convert).collect(Collectors.toList());
         notifications.forEach(
             n -> {
-                n.setId(RandomString.generate());
+                n.setId(UuidString.generateRandom());
                 n.setCreatedAt(now);
             }
         );

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/QualityRuleServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/QualityRuleServiceImpl.java
@@ -29,7 +29,7 @@ import io.gravitee.rest.api.model.quality.QualityRuleEntity;
 import io.gravitee.rest.api.model.quality.UpdateQualityRuleEntity;
 import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.QualityRuleService;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.QualityRuleNotFoundException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.Collections;
@@ -162,7 +162,7 @@ public class QualityRuleServiceImpl extends AbstractService implements QualityRu
 
     private QualityRule convert(final NewQualityRuleEntity qualityRuleEntity) {
         final QualityRule qualityRule = new QualityRule();
-        qualityRule.setId(RandomString.generate());
+        qualityRule.setId(UuidString.generateRandom());
         qualityRule.setName(qualityRuleEntity.getName());
         qualityRule.setDescription(qualityRuleEntity.getDescription());
         qualityRule.setWeight(qualityRuleEntity.getWeight());

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RatingServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RatingServiceImpl.java
@@ -33,7 +33,7 @@ import io.gravitee.rest.api.model.*;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.*;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.ApiRatingUnavailableException;
 import io.gravitee.rest.api.service.exceptions.RatingAlreadyExistsException;
 import io.gravitee.rest.api.service.exceptions.RatingNotFoundException;
@@ -125,7 +125,7 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
             final Rating rating = findModelById(answerEntity.getRatingId());
 
             final RatingAnswer ratingAnswer = new RatingAnswer();
-            ratingAnswer.setId(RandomString.generate());
+            ratingAnswer.setId(UuidString.generateRandom());
             ratingAnswer.setRating(answerEntity.getRatingId());
             ratingAnswer.setUser(getAuthenticatedUsername());
             ratingAnswer.setComment(answerEntity.getComment());
@@ -394,7 +394,7 @@ public class RatingServiceImpl extends AbstractService implements RatingService 
 
     private Rating convert(final NewRatingEntity ratingEntity) {
         final Rating rating = new Rating();
-        rating.setId(RandomString.generate());
+        rating.setId(UuidString.generateRandom());
         rating.setReferenceId(ratingEntity.getApi());
         rating.setReferenceType(RatingReferenceType.API);
         rating.setRate(ratingEntity.getRate());

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/RoleServiceImpl.java
@@ -37,7 +37,7 @@ import io.gravitee.rest.api.service.AuditService;
 import io.gravitee.rest.api.service.MembershipService;
 import io.gravitee.rest.api.service.RoleService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.*;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
@@ -131,7 +131,7 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
             ) {
                 throw new RoleAlreadyExistsException(role.getScope(), role.getName());
             }
-            role.setId(RandomString.generate());
+            role.setId(UuidString.generateRandom());
             role.setCreatedAt(new Date());
             role.setUpdatedAt(role.getCreatedAt());
             role.setReferenceId(organizationId);
@@ -587,7 +587,7 @@ public class RoleServiceImpl extends AbstractService implements RoleService {
     private Role createSystemRoleWithoutPermissions(String name, RoleScope scope, Date date) {
         LOGGER.info("      - <" + scope + "> " + name + " (system)");
         Role systemRole = new Role();
-        systemRole.setId(RandomString.generate());
+        systemRole.setId(UuidString.generateRandom());
         systemRole.setName(name);
         systemRole.setDescription("System Role. Created by Gravitee.io");
         systemRole.setDefaultRole(false);

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/SubscriptionServiceImpl.java
@@ -41,7 +41,7 @@ import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.model.subscription.SubscriptionQuery;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.notification.ApiHook;
 import io.gravitee.rest.api.service.notification.ApplicationHook;
@@ -300,7 +300,7 @@ public class SubscriptionServiceImpl extends AbstractService implements Subscrip
 
             Subscription subscription = new Subscription();
             subscription.setPlan(plan);
-            subscription.setId(RandomString.generate());
+            subscription.setId(UuidString.generateRandom());
             subscription.setApplication(application);
             subscription.setCreatedAt(new Date());
             subscription.setUpdatedAt(subscription.getCreatedAt());

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TicketServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/TicketServiceImpl.java
@@ -35,7 +35,7 @@ import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
 import io.gravitee.rest.api.service.*;
 import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.EmailRequiredException;
 import io.gravitee.rest.api.service.exceptions.SupportUnavailableException;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
@@ -164,7 +164,7 @@ public class TicketServiceImpl extends TransactionalService implements TicketSer
             sendUserNotification(user, api, applicationEntity);
 
             Ticket ticket = convert(ticketEntity);
-            ticket.setId(RandomString.generate());
+            ticket.setId(UuidString.generateRandom());
             ticket.setCreatedAt(new Date());
             ticket.setFromUser(userId);
 

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/UserServiceImpl.java
@@ -63,7 +63,7 @@ import io.gravitee.rest.api.service.builder.EmailNotificationBuilder;
 import io.gravitee.rest.api.service.common.GraviteeContext;
 import io.gravitee.rest.api.service.common.JWTHelper.ACTION;
 import io.gravitee.rest.api.service.common.JWTHelper.Claims;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.configuration.identity.IdentityProviderService;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.search.SearchResult;
@@ -675,7 +675,7 @@ public class UserServiceImpl extends AbstractService implements UserService, Ini
             }
 
             User user = convert(newExternalUserEntity);
-            user.setId(RandomString.generate());
+            user.setId(UuidString.generateRandom());
             user.setOrganizationId(organizationId);
             user.setStatus(autoRegistrationEnabled ? UserStatus.ACTIVE : UserStatus.PENDING);
 

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/WorkflowServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/WorkflowServiceImpl.java
@@ -22,7 +22,7 @@ import io.gravitee.rest.api.model.WorkflowReferenceType;
 import io.gravitee.rest.api.model.WorkflowState;
 import io.gravitee.rest.api.model.WorkflowType;
 import io.gravitee.rest.api.service.WorkflowService;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.Date;
 import java.util.List;
@@ -53,7 +53,7 @@ public class WorkflowServiceImpl extends TransactionalService implements Workflo
         final String comment
     ) {
         final Workflow workflow = new Workflow();
-        workflow.setId(RandomString.generate());
+        workflow.setId(UuidString.generateRandom());
         workflow.setReferenceType(referenceType.name());
         workflow.setReferenceId(referenceId);
         workflow.setType(type.name());

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/configuration/application/registration/ClientRegistrationServiceImpl.java
@@ -35,7 +35,7 @@ import io.gravitee.rest.api.model.configuration.application.registration.Initial
 import io.gravitee.rest.api.model.configuration.application.registration.NewClientRegistrationProviderEntity;
 import io.gravitee.rest.api.model.configuration.application.registration.UpdateClientRegistrationProviderEntity;
 import io.gravitee.rest.api.service.AuditService;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.configuration.application.ClientRegistrationService;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.impl.AbstractService;
@@ -130,7 +130,7 @@ public class ClientRegistrationServiceImpl extends AbstractService implements Cl
             // Check renew_client_secret configuration
             renewClientSecretSupport(clientRegistrationProvider);
 
-            clientRegistrationProvider.setId(RandomString.generate());
+            clientRegistrationProvider.setId(UuidString.generateRandom());
 
             DynamicClientRegistrationProviderClient registrationProviderClient = getDCRClient(true, convert(clientRegistrationProvider));
 

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/impl/promotion/PromotionServiceImpl.java
@@ -45,7 +45,7 @@ import io.gravitee.rest.api.service.cockpit.services.CockpitReply;
 import io.gravitee.rest.api.service.cockpit.services.CockpitReplyStatus;
 import io.gravitee.rest.api.service.cockpit.services.CockpitService;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.*;
 import io.gravitee.rest.api.service.impl.AbstractService;
 import io.gravitee.rest.api.service.jackson.ser.api.ApiSerializer;
@@ -143,7 +143,7 @@ public class PromotionServiceImpl extends AbstractService implements PromotionSe
         }
 
         Promotion promotionToSave = convert(apiId, apiDefinition, currentEnvironmentEntity, promotionRequest, author);
-        promotionToSave.setId(RandomString.generate());
+        promotionToSave.setId(UuidString.generateRandom());
         Promotion createdPromotion = null;
         try {
             createdPromotion = promotionRepository.create(promotionToSave);

--- a/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/notifiers/impl/WebNotifierServiceImpl.java
+++ b/gravitee-rest-api-service/src/main/java/io/gravitee/rest/api/service/notifiers/impl/WebNotifierServiceImpl.java
@@ -19,7 +19,7 @@ import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpMethod;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.common.http.MediaType;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import io.gravitee.rest.api.service.notifiers.WebNotifierService;
 import io.vertx.core.AsyncResult;
@@ -134,7 +134,7 @@ public class WebNotifierServiceImpl implements WebNotifierService {
         options.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
         options.putHeader(HttpHeaders.CONTENT_LENGTH, Integer.toString(body.length()));
         headers.forEach(options::putHeader);
-        options.putHeader("X-Gravitee-Request-Id", RandomString.generate());
+        options.putHeader("X-Gravitee-Request-Id", UuidString.generateRandom());
 
         Future<HttpClientRequest> requestFuture = httpClient.request(options);
 

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/common/UuidStringTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/common/UuidStringTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 The Gravitee team (http://gravitee.io)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gravitee.rest.api.common;
+
+import static org.junit.Assert.*;
+
+import io.gravitee.rest.api.service.common.UuidString;
+import org.junit.Test;
+
+/**
+ * @author GraviteeSource Team
+ */
+public class UuidStringTest {
+
+    @Test
+    public void generateForEnvironment_should_generate_same_uuids_if_called_with_same_fields() {
+        String firstUuid = UuidString.generateForEnvironment("environmentId", "field1", "field2", "field3");
+        String secondUuid = UuidString.generateForEnvironment("environmentId", "field1", "field2", "field3");
+
+        assertEquals(firstUuid, secondUuid);
+    }
+
+    @Test
+    public void generateForEnvironment_should_generate_different_uuids_if_called_with_different_fields() {
+        String firstUuid = UuidString.generateForEnvironment("environmentId", "field1", "field2", "field3");
+        String secondUuid = UuidString.generateForEnvironment("environmentId", "field1", "field2", "field4");
+
+        assertNotEquals(firstUuid, secondUuid);
+    }
+
+    @Test
+    public void generateForEnvironment_should_generate_different_uuid_if_called_with_null_fields() {
+        String firstUuid = UuidString.generateForEnvironment("environmentId", "field1", "field2", null);
+        String secondUuid = UuidString.generateForEnvironment("environmentId", "field1", "field2", null);
+
+        assertNotEquals(firstUuid, secondUuid);
+    }
+}

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_CreateOrUpdatePagesTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_CreateOrUpdatePagesTest.java
@@ -26,7 +26,7 @@ import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.model.Page;
 import io.gravitee.repository.management.model.PageReferenceType;
 import io.gravitee.rest.api.model.PageEntity;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.PageNotFoundException;
 import io.gravitee.rest.api.service.impl.PageServiceImpl;
 import java.util.Collections;
@@ -61,21 +61,21 @@ public class PageService_CreateOrUpdatePagesTest {
     @Test
     public void shouldCreateOrUpdatePages() throws TechnicalException {
         PageEntity page1 = new PageEntity();
-        page1.setId(RandomString.generate());
+        page1.setId(UuidString.generateRandom());
         page1.setName("Page 1");
         page1.setType("SWAGGER");
         page1.setReferenceType("API");
         page1.setReferenceId(API_ID);
 
         PageEntity page2 = new PageEntity();
-        page2.setId(RandomString.generate());
+        page2.setId(UuidString.generateRandom());
         page2.setName("Page 2");
         page2.setType("MARKDOWN");
         page2.setReferenceType("API");
         page2.setReferenceId(API_ID);
 
         PageEntity page3 = new PageEntity();
-        page3.setId(RandomString.generate());
+        page3.setId(UuidString.generateRandom());
         page3.setName("Sub Page 3");
         page3.setType("ASCIIDOC");
         page3.setParentId(page1.getId());
@@ -85,7 +85,7 @@ public class PageService_CreateOrUpdatePagesTest {
         when(pageRepository.create(any(Page.class))).thenAnswer(returnsFirstArg());
         when(pageRepository.update(any(Page.class))).thenAnswer(returnsFirstArg());
 
-        String page1NewId = RandomString.generateForEnvironment(ENVIRONMENT_ID, API_ID, page1.getId());
+        String page1NewId = UuidString.generateForEnvironment(ENVIRONMENT_ID, API_ID, page1.getId());
         Page page = new Page();
         page.setId(page1NewId);
         page.setName(page1.getName());

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_DuplicatePagesTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_DuplicatePagesTest.java
@@ -17,7 +17,6 @@ package io.gravitee.rest.api.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.not;
-import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -26,7 +25,7 @@ import io.gravitee.repository.exceptions.TechnicalException;
 import io.gravitee.repository.management.api.PageRepository;
 import io.gravitee.repository.management.model.Page;
 import io.gravitee.rest.api.model.*;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.impl.PageServiceImpl;
 import java.util.*;
 import org.junit.Test;
@@ -58,17 +57,17 @@ public class PageService_DuplicatePagesTest {
     @Test
     public void shouldDuplicatePages() throws TechnicalException {
         PageEntity page1 = new PageEntity();
-        page1.setId(RandomString.generate());
+        page1.setId(UuidString.generateRandom());
         page1.setName("Page 1");
         page1.setType("SWAGGER");
 
         PageEntity page2 = new PageEntity();
-        page2.setId(RandomString.generate());
+        page2.setId(UuidString.generateRandom());
         page2.setName("Page 2");
         page2.setType("MARKDOWN");
 
         PageEntity page3 = new PageEntity();
-        page3.setId(RandomString.generate());
+        page3.setId(UuidString.generateRandom());
         page3.setName("Sub Page 3");
         page3.setType("ASCIIDOC");
         page3.setParentId(page2.getId());

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDescriptorTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDescriptorTest.java
@@ -33,7 +33,7 @@ import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PageSourceEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.impl.GraviteeDescriptorServiceImpl;
 import io.gravitee.rest.api.service.impl.PageServiceImpl;
 import io.gravitee.rest.api.service.search.SearchEngineService;
@@ -118,7 +118,7 @@ public class PageService_ImportDescriptorTest {
         PageSource ps = new PageSource();
         ps.setType(pageSource.getType());
         ps.setConfiguration(pageSource.getConfiguration());
-        when(newPage.getId()).thenReturn(RandomString.generate());
+        when(newPage.getId()).thenReturn(UuidString.generateRandom());
         when(newPage.getSource()).thenReturn(ps);
         when(newPage.getType()).thenReturn("MARKDOWN");
         when(newPage.getReferenceType()).thenReturn(PageReferenceType.ENVIRONMENT);

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDirectoryTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PageService_ImportDirectoryTest.java
@@ -33,7 +33,7 @@ import io.gravitee.rest.api.model.PageEntity;
 import io.gravitee.rest.api.model.PageSourceEntity;
 import io.gravitee.rest.api.model.Visibility;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.impl.PageServiceImpl;
 import io.gravitee.rest.api.service.search.SearchEngineService;
 import io.gravitee.rest.api.service.spring.ImportConfiguration;
@@ -115,7 +115,7 @@ public class PageService_ImportDirectoryTest {
         PageSource ps = new PageSource();
         ps.setType(pageSource.getType());
         ps.setConfiguration(pageSource.getConfiguration());
-        when(newPage.getId()).thenReturn(RandomString.generate());
+        when(newPage.getId()).thenReturn(UuidString.generateRandom());
         when(newPage.isPublished()).thenReturn(Boolean.TRUE);
         when(newPage.getSource()).thenReturn(ps);
         when(newPage.getType()).thenReturn("MARKDOWN");

--- a/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PlanService_DuplicatePlansTest.java
+++ b/gravitee-rest-api-service/src/test/java/io/gravitee/rest/api/service/PlanService_DuplicatePlansTest.java
@@ -29,7 +29,7 @@ import io.gravitee.rest.api.model.api.ApiEntity;
 import io.gravitee.rest.api.model.api.ApiLifecycleState;
 import io.gravitee.rest.api.model.parameters.Key;
 import io.gravitee.rest.api.model.parameters.ParameterReferenceType;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.impl.PlanServiceImpl;
 import java.util.Collections;
 import java.util.List;
@@ -95,7 +95,7 @@ public class PlanService_DuplicatePlansTest {
     @NotNull
     private PlanEntity getAPlanEntity(String name, PlanSecurityType oauth2) {
         PlanEntity plan = new PlanEntity();
-        plan.setId(RandomString.generate());
+        plan.setId(UuidString.generateRandom());
         plan.setSecurity(oauth2);
         plan.setType(PlanType.API);
         plan.setStatus(PlanStatus.PUBLISHED);

--- a/gravitee-rest-api-services/gravitee-rest-api-services-dictionary/src/main/java/io/gravitee/rest/api/services/dictionary/provider/http/HttpProvider.java
+++ b/gravitee-rest-api-services/gravitee-rest-api-services-dictionary/src/main/java/io/gravitee/rest/api/services/dictionary/provider/http/HttpProvider.java
@@ -19,7 +19,7 @@ import io.gravitee.common.http.HttpHeaders;
 import io.gravitee.common.http.HttpStatusCode;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.utils.NodeUtils;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.services.dictionary.model.DynamicProperty;
 import io.gravitee.rest.api.services.dictionary.provider.Provider;
 import io.gravitee.rest.api.services.dictionary.provider.http.configuration.HttpProviderConfiguration;
@@ -94,7 +94,7 @@ public class HttpProvider implements Provider {
 
         //headers
         options.putHeader(HttpHeaders.USER_AGENT, NodeUtils.userAgent(node));
-        options.putHeader("X-Gravitee-Request-Id", RandomString.generate());
+        options.putHeader("X-Gravitee-Request-Id", UuidString.generateRandom());
 
         if (configuration.getHeaders() != null) {
             configuration.getHeaders().forEach(httpHeader -> options.putHeader(httpHeader.getName(), httpHeader.getValue()));

--- a/gravitee-rest-api-services/gravitee-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/http/HttpProvider.java
+++ b/gravitee-rest-api-services/gravitee-rest-api-services-dynamic-properties/src/main/java/io/gravitee/rest/api/services/dynamicproperties/provider/http/HttpProvider.java
@@ -21,7 +21,7 @@ import io.gravitee.definition.model.services.dynamicproperty.DynamicPropertyServ
 import io.gravitee.definition.model.services.dynamicproperty.http.HttpDynamicPropertyProviderConfiguration;
 import io.gravitee.node.api.Node;
 import io.gravitee.node.api.utils.NodeUtils;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.services.dynamicproperties.model.DynamicProperty;
 import io.gravitee.rest.api.services.dynamicproperties.provider.Provider;
 import io.gravitee.rest.api.services.dynamicproperties.provider.http.mapper.JoltMapper;
@@ -92,7 +92,7 @@ public class HttpProvider implements Provider {
 
         //headers
         options.putHeader(HttpHeaders.USER_AGENT, NodeUtils.userAgent(node));
-        options.putHeader("X-Gravitee-Request-Id", RandomString.generate());
+        options.putHeader("X-Gravitee-Request-Id", UuidString.generateRandom());
 
         if (dpConfiguration.getHeaders() != null) {
             dpConfiguration.getHeaders().forEach(httpHeader -> options.putHeader(httpHeader.getName(), httpHeader.getValue()));

--- a/gravitee-rest-api-services/gravitee-rest-api-services-v3-upgrader/src/main/java/io/gravitee/rest/api/services/v3/upgrader/V3UpgraderService.java
+++ b/gravitee-rest-api-services/gravitee-rest-api-services-v3-upgrader/src/main/java/io/gravitee/rest/api/services/v3/upgrader/V3UpgraderService.java
@@ -22,7 +22,7 @@ import io.gravitee.repository.management.api.MembershipRepository;
 import io.gravitee.repository.management.api.RoleRepository;
 import io.gravitee.repository.management.model.*;
 import io.gravitee.rest.api.service.common.GraviteeContext;
-import io.gravitee.rest.api.service.common.RandomString;
+import io.gravitee.rest.api.service.common.UuidString;
 import io.gravitee.rest.api.service.exceptions.TechnicalManagementException;
 import java.util.*;
 import java.util.Map.Entry;
@@ -177,7 +177,7 @@ public class V3UpgraderService extends AbstractService {
                         logger.info("No org role exist with the same name");
 
                         orgRole = new Role();
-                        orgRole.setId(RandomString.generate());
+                        orgRole.setId(UuidString.generateRandom());
                         orgRole.setName(envRole.getName());
                         orgRole.setDefaultRole(envRole.isDefaultRole());
                         orgRole.setReferenceId(GraviteeContext.getDefaultOrganization());
@@ -209,7 +209,7 @@ public class V3UpgraderService extends AbstractService {
                                 );
                         if (orgMembershipsWithRole.isEmpty()) {
                             Membership newOrganizationMembership = membership;
-                            newOrganizationMembership.setId(RandomString.generate());
+                            newOrganizationMembership.setId(UuidString.generateRandom());
                             newOrganizationMembership.setReferenceId("DEFAULT");
                             newOrganizationMembership.setReferenceType(MembershipReferenceType.ORGANIZATION);
                             newOrganizationMembership.setRoleId(orgRole.getId());


### PR DESCRIPTION
**Issue**

https://github.com/gravitee-io/issues/issues/5941

**Description**

`RandomString.generateForEnvironment` wasn't generating a random string, so when creating multiple documents on api creation, they all had the same generated ID, which leads to a 'duplicate key' exception. Modified it to generate a random string instead when one provided field is null (in that case, the new page ID).

